### PR TITLE
Use PostgreSQL in all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,8 @@ source 'https://rubygems.org'
 #################
 
 gem 'rails', '4.2.0'
-# gem 'rails', '4.1.6'
 gem 'sprockets-rails', '~> 2.0'
-# gem 'pg', '0.18.1' # JDavis: consider using the postgres gem for all environments.
+gem 'pg'
 
 #############
 # Front-end #
@@ -58,11 +57,9 @@ group :development do
   gem 'railroady'
   gem 'letter_opener'
   gem 'spring'
-  gem 'sqlite3' # JDavis: Since Heroku uses postgres, we should do the same in development.
 end
 
 group :production do
-  gem 'pg'
   gem 'rails_12factor'
   gem 'thin'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
     stripe (1.20.1)
       json (~> 1.8.1)
       mime-types (>= 1.25, < 3.0)
@@ -278,7 +277,6 @@ DEPENDENCIES
   shareable
   spring
   sprockets-rails (~> 2.0)
-  sqlite3
   stripe
   thin
   turbolinks

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,12 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: 5
-  timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: operationcode_development
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3
+  database: operationcode_test


### PR DESCRIPTION
Use the same database in all environments. To get the database running, you must have a version of postgres installed. Once the daemon is set up, you need to run `bundle exec rake db:setup` to create the database and perform the initial migrations.