### PR TITLE
Center columns in footer. Fixes #35.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,7 +17,7 @@
 
  .social-links a {
    text-align: center;
-   float: left;
+   display: inline-block;
    width: 36px;
    height: 36px;
    border: 1px solid white;

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,8 +1,7 @@
 <footer class="center">
     <div class="container">
       <div class="row">
-        <div class="col-md-4">
-
+        <div class="col-md-3">
           <h2>Social</h2>
           <div class="social-links">
               <a href="https://twitter.com/operation_code"
@@ -14,27 +13,27 @@
               <a href="https://instagram.com/operation_code"
               id="instagram"><i class="fa fa-instagram fa-lg"></i></a>
           </div>
-
-          <div class="col-md-4">
-            <h2>Connect</h2>
-            <p><a href="mailto:contact@operationcode.org">email</a></p>
-            <p><a href="/faq">FAQs</a></p>
-         </div>
-
-          <div class="col-md-4">
-            <h2>About us</h2>
-            <p><a href="/contributors">in-kind donors</a></p>
-            <p><a href="/press">press</a></p>
-            <p><a href="  https://s3-us-west-2.amazonaws.com/operationcode/operation_code_case_statement.pdf">case statement</a></p>
-          </div>
-
-          <div class="col-md-4">
-            <h2>Resources</h2>
-<!--             <p><a href="/media">download assets</a></p> -->
-            <p><a href="/speakerrequest">request a speaker</a></p>
-          </div>
-
         </div>
+
+        <div class="col-md-3">
+          <h2>Connect</h2>
+          <p><a href="mailto:contact@operationcode.org">email</a></p>
+          <p><a href="/faq">FAQs</a></p>
+        </div>
+
+        <div class="col-md-3">
+          <h2>About us</h2>
+          <p><a href="/contributors">in-kind donors</a></p>
+          <p><a href="/press">press</a></p>
+          <p><a href="  https://s3-us-west-2.amazonaws.com/operationcode/operation_code_case_statement.pdf">case statement</a></p>
+        </div>
+
+        <div class="col-md-3">
+          <h2>Resources</h2>
+<!--             <p><a href="/media">download assets</a></p> -->
+          <p><a href="/speakerrequest">request a speaker</a></p>
+        </div>
+
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #35.
Change class used on divs in footer to use col-md-3 instead of col-md-4.
Change social-links to inline-block instead of float: left (centers
them).
Fix placement of closing div tag.