### PR TITLE
Fix typo on landing page: American's > Americans

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -16,7 +16,7 @@ technical talent shortage. -->
       </li>
       <li>
         <img src="/assets/scholarship.jpg">
-        <div id="overlay"><h1 class="small_screen_h2">Expanding the software and technology talent pipeline with American's who've served their country and can code. Service to country continues.</h1></div>
+        <div id="overlay"><h1 class="small_screen_h2">Expanding the software and technology talent pipeline with Americans who've served their country and can code. Service to country continues.</h1></div>
       </li>
     </div>
   </div>


### PR DESCRIPTION
Fix typo, take out unneeded apostrophe for plural form of Americans