### PR TITLE
Changes/fixes to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ included in the project. Everyone is encouraged to contribute to the project by 
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/operationcode/operationcode.git
+   git clone https://github.com/<your-username>/operationcode.git
    # Navigate to the newly cloned directory
    cd operationcode
    # To setup dependencies
@@ -131,18 +131,15 @@ included in the project. Everyone is encouraged to contribute to the project by 
    git pull upstream master
    ```
 
-3. Create a new topic branch (off the main project development branch) to
-   contain your feature, change, or fix:
+3. Create a new topic branch (off the master branch) to contain your feature, change, or fix:
 
    ```bash
    git checkout -b <topic-branch-name>
    ```
 
-4. Commit your changes in logical chunks. Please adhere to these [git commit
-   message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
    or your code is unlikely be merged into the main project. Use Git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before making them public.
+   [interactive rebase](https://help.github.com/articles/interactive-rebase) feature to tidy up your commits before making them public.
 
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 
@@ -156,8 +153,7 @@ included in the project. Everyone is encouraged to contribute to the project by 
    git push origin <topic-branch-name>
    ```
 
-7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
-    with a clear title and description against the `master` branch.
+7. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/) with a clear title and description against the `master` branch.
 
 ## Add yourself
 


### PR DESCRIPTION
- fixed clone url example (removed extra `operationcode`)
- clarifies to make a branch off the `master` branch instead of `main project development branch`