### PR TITLE
updates set up documentation on how to start the thin server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,8 @@ included in the project. Everyone is encouraged to contribute to the project by 
    bundle install
    # To create development and test databases
    bundle exec rake db:setup
-   # To start the [server](http://localhost:3000)
-   bundle exec rails s
+   # To start the [server](http://localhost:3000) (if you receive a certificate error in your browser, go ahead and accept the certificate)
+   thin start --ssl
    # Assign the original repo to a remote called "upstream"
    git remote add upstream https://github.com/operationcode/operationcode.git
    ```


### PR DESCRIPTION
I found that bundle exec rails s now throws an error when trying to start this application locally.  However, these updated instructions do start the local server successfully.