### PR TITLE
Fix slack bot invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,8 @@ included in the project. Everyone is encouraged to contribute to the project by 
    bundle install
    # To create development and test databases
    bundle exec rake db:setup
-   # To start the [server](http://localhost:3000)
-   bundle exec rails s
+   # To start the [server](http://localhost:3000) (if you receive a certificate error in your browser, go ahead and accept the certificate)
+   thin start --ssl
    # Assign the original repo to a remote called "upstream"
    git remote add upstream https://github.com/operationcode/operationcode.git
    ```

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rails server thin -p $PORT -e $RACK_ENV
-sidekiq: bundle exec sidekiq
+sidekiq: bundle exec sidekiq -e production -C config/sidekiq.yml

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+require 'sidekiq'
+
+Sidekiq.configure_client do |config|
+  config.redis = { size: 1 }
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = { size: 2 }
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,1 @@
+:concurrency: 1


### PR DESCRIPTION
Fix for #102 

It's likely that Slackbot wasn't working due to too many sidekiq clients and threads trying to use our redis instance at once.  When I took a look at our production logs, I saw lots of this error "2015-12-06T22:30:39.643309+00:00 app[sidekiq.1]: 3 TID-osjt5y8a8 ERROR: Error fetching job: ERR max number of clients reached"

This fix is based on this Stack Overflow solution: http://stackoverflow.com/a/17826254

Here's some more information on the error we were seeing:
https://github.com/mperham/sidekiq/issues/117
http://manuel.manuelles.nl/blog/2012/11/13/sidekiq-on-heroku-with-redistogo-nano/
https://github.com/mperham/sidekiq/wiki/Advanced-Options