### PR TITLE
adds new relic gem to add monitoring to the Operation Code site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'sprockets-rails', '~> 2.0'
 gem 'pg'
 gem 'sidekiq'
 gem 'thin'
+gem 'newrelic_rpm'
 
 #############
 # Front-end #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,7 @@ GEM
     minitest (5.8.3)
     multi_json (1.11.2)
     netrc (0.11.0)
+    newrelic_rpm (3.15.0.314)
     nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     orm_adapter (0.5.0)
@@ -366,6 +367,7 @@ DEPENDENCIES
   jquery-rails
   jquery-turbolinks
   letter_opener
+  newrelic_rpm
   pg
   pry-byebug
   pry-rails


### PR DESCRIPTION
In attempting to get New Relic working with the site, I realized that we do not have the new relic gem in the app.  This may be why it was not working.  This pull request adds that gem in :)