### PR TITLE
do not force ssl when running tests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,6 @@ class ApplicationController < ActionController::Base
 
   def ssl_configured?
     !Rails.env.production?
+    !Rails.env.test?
   end
 end


### PR DESCRIPTION
Fixes #124 

Forcing SSL for the test environment was causing the tests to fail.  It should not be needed for the testing environments.