### PR TITLE
Auto add vets to MailChimp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'github-markup', '~> 1.2.1'
 gem 'skylight'
 gem 'figaro' #app configuration using ENV variables and a single YAML file
 gem 'jekyll' #blogging gem
+gem 'gibbon' #API wrapper for the Mailchimp API
 
 #####################
 # Development Tools #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -136,6 +138,9 @@ GEM
     formtastic (3.1.3)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.4.1)
+    gibbon (2.2.1)
+      faraday (>= 0.9.1)
+      multi_json (>= 1.11.0)
     github-markup (1.2.1)
       posix-spawn (~> 0.3.8)
     globalid (0.3.6)
@@ -202,6 +207,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.3)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     netrc (0.11.0)
     newrelic_rpm (3.15.0.314)
     nokogiri (1.6.6.4)
@@ -360,6 +366,7 @@ DEPENDENCIES
   factory_girl_rails
   figaro
   font-awesome-rails
+  gibbon
   github-markup (~> 1.2.1)
   google-webfonts-rails
   jbuilder (~> 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,6 @@ class ApplicationController < ActionController::Base
 
   def ssl_configured?
     !Rails.env.production?
+    !Rails.env.test?
   end
 end

--- a/app/controllers/veterans_controller.rb
+++ b/app/controllers/veterans_controller.rb
@@ -31,6 +31,20 @@ class VeteransController < ApplicationController
       if @veteran.save
         UserMailer.welcome(@veteran).deliver_now
         @veteran.send_slack_invitation
+
+        gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
+
+        gibbon.lists(ENV['MAILCHIMP_LIST_ID']).members.create(
+          body: {
+            email_address: @veteran.email,
+            status: 'subscribed',
+            merge_fields: {
+              FNAME: @veteran.first_name,
+              LNAME: @veteran.last_name
+            }
+          }
+        )
+
         format.html { redirect_to action_path, notice: 'Thanks for signing up!' }
         format.json { render :show, status: :created, location: @veteran }
       else

--- a/app/controllers/veterans_controller.rb
+++ b/app/controllers/veterans_controller.rb
@@ -31,19 +31,7 @@ class VeteransController < ApplicationController
       if @veteran.save
         UserMailer.welcome(@veteran).deliver_now
         @veteran.send_slack_invitation
-
-        gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
-
-        gibbon.lists(ENV['MAILCHIMP_LIST_ID']).members.create(
-          body: {
-            email_address: @veteran.email,
-            status: 'subscribed',
-            merge_fields: {
-              FNAME: @veteran.first_name,
-              LNAME: @veteran.last_name
-            }
-          }
-        )
+        @veteran.add_to_mailchimp
 
         format.html { redirect_to action_path, notice: 'Thanks for signing up!' }
         format.json { render :show, status: :created, location: @veteran }

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -28,4 +28,19 @@ class Veteran < ActiveRecord::Base
   def send_slack_invitation
     SlackInviterJob.perform_later(email)
   end
+
+  def add_to_mailchimp
+    gibbon = Gibbon::Request.new(api_key: ENV['MAILCHIMP_API_KEY'])
+
+    gibbon.lists(ENV['MAILCHIMP_LIST_ID']).members.create(
+      body: {
+        email_address: email,
+        status: 'subscribed',
+        merge_fields: {
+          FNAME: first_name,
+          LNAME: last_name
+        }
+      }
+    )
+  end
 end

--- a/spec/controllers/veterans_controller_spec.rb
+++ b/spec/controllers/veterans_controller_spec.rb
@@ -34,7 +34,6 @@ describe VeteransController do
     end
 
     context "when the record saves successfully" do
-
       describe "#html" do
         it "redirects to the action_path" do
           post :create, veteran: veteran_params, format: :html

--- a/spec/controllers/veterans_controller_spec.rb
+++ b/spec/controllers/veterans_controller_spec.rb
@@ -22,20 +22,10 @@ describe VeteransController do
       }
     end
 
-    let(:api_key) { 'abc123' }
-    let(:list_id) { 'my_list_id' }
-    let(:gibbon)  { Gibbon::Request.new(api_key: api_key) }
-
-
     before do
       allow_any_instance_of(Veteran).to receive(:new)
       allow_any_instance_of(Veteran).to receive(:send_slack_invitation)
-
-      ENV['MAILCHIMP_API_KEY'] = api_key
-      ENV['MAILCHIMP_LIST_ID'] = list_id
-
-      allow(Gibbon::Request).to receive(:new).and_return(gibbon)
-      allow(gibbon).to receive_message_chain(:lists, :members, :create).and_return('200')
+      allow_any_instance_of(Veteran).to receive(:add_to_mailchimp)
     end
 
     it "makes a new record with the params" do
@@ -44,6 +34,7 @@ describe VeteransController do
     end
 
     context "when the record saves successfully" do
+
       describe "#html" do
         it "redirects to the action_path" do
           post :create, veteran: veteran_params, format: :html
@@ -69,31 +60,9 @@ describe VeteransController do
           post :create, veteran: veteran_params, format: :html
         end
 
-        context 'adding to the Mailchimp list' do
-          it 'creates a new instance of Gibbon' do
-            expect(Gibbon::Request).to receive(:new).with(api_key: api_key).and_return(gibbon)
-            post :create, veteran: veteran_params, format: :html
-          end
-
-          it 'finds the the correct list' do
-            expect(gibbon).to receive(:lists).with(list_id)
-            post :create, veteran: veteran_params, format: :html
-          end
-
-          it 'adds the veteran as a member to the list' do
-            expect(gibbon).to receive_message_chain(:lists, :members, :create).with(
-              body: {
-                email_address: veteran_params[:email],
-                status: 'subscribed',
-                merge_fields: {
-                  FNAME: veteran_params[:first_name],
-                  LNAME: veteran_params[:last_name]
-                }
-              }
-            )
-
-            post :create, veteran: veteran_params, format: :html
-          end
+        it "adds to Mailchimp" do
+          expect_any_instance_of(Veteran).to receive(:add_to_mailchimp).exactly(1).times
+          post :create, veteran: veteran_params, format: :html
         end
       end
 

--- a/spec/controllers/veterans_controller_spec.rb
+++ b/spec/controllers/veterans_controller_spec.rb
@@ -22,9 +22,20 @@ describe VeteransController do
       }
     end
 
+    let(:api_key) { 'abc123' }
+    let(:list_id) { 'my_list_id' }
+    let(:gibbon)  { Gibbon::Request.new(api_key: api_key) }
+
+
     before do
       allow_any_instance_of(Veteran).to receive(:new)
       allow_any_instance_of(Veteran).to receive(:send_slack_invitation)
+
+      ENV['MAILCHIMP_API_KEY'] = api_key
+      ENV['MAILCHIMP_LIST_ID'] = list_id
+
+      allow(Gibbon::Request).to receive(:new).and_return(gibbon)
+      allow(gibbon).to receive_message_chain(:lists, :members, :create).and_return('200')
     end
 
     it "makes a new record with the params" do
@@ -56,6 +67,33 @@ describe VeteransController do
         it "sends slack invitation" do
           expect_any_instance_of(Veteran).to receive(:send_slack_invitation).exactly(1).times
           post :create, veteran: veteran_params, format: :html
+        end
+
+        context 'adding to the Mailchimp list' do
+          it 'creates a new instance of Gibbon' do
+            expect(Gibbon::Request).to receive(:new).with(api_key: api_key).and_return(gibbon)
+            post :create, veteran: veteran_params, format: :html
+          end
+
+          it 'finds the the correct list' do
+            expect(gibbon).to receive(:lists).with(list_id)
+            post :create, veteran: veteran_params, format: :html
+          end
+
+          it 'adds the veteran as a member to the list' do
+            expect(gibbon).to receive_message_chain(:lists, :members, :create).with(
+              body: {
+                email_address: veteran_params[:email],
+                status: 'subscribed',
+                merge_fields: {
+                  FNAME: veteran_params[:first_name],
+                  LNAME: veteran_params[:last_name]
+                }
+              }
+            )
+
+            post :create, veteran: veteran_params, format: :html
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #22 

When this is deployed, I will need to add two environmental variables to our Heroku setup.  1 with the API key for our Mailchimp account and the other for the Mailchimp list id.