### PR TITLE
Refine calendar page content & styles - emphasis on mobile-friendly

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,7 +1,8 @@
 @import "active_admin";
 @import "font-awesome";
 @import "bootstrap_and_customization";
-@import 'bootstrap/variables';
+@import "bootstrap/variables";
+@import "calendar";
 
 
 .col-lg-10 {

--- a/app/assets/stylesheets/calendar.css.scss
+++ b/app/assets/stylesheets/calendar.css.scss
@@ -1,0 +1,35 @@
+.calendar-container {
+  text-align: center;
+}
+
+.calendar-header {
+  border-bottom: 1px solid $gray-lighter;
+  font-size: 28px;
+  padding-bottom: 9px;
+  text-align: left;
+
+  @media(min-width: 768px) {
+    font-size: 36px;
+  }
+}
+
+.calendar-subheader {
+  display: block;
+  padding: 10px 0 0;
+
+  @media(min-width: 768px) {
+    display: inline;
+    padding: 0 0 0 20px;
+  }
+}
+
+.calendar-iframe {
+  border-radius: 5px;
+  height: 480px; // mobile-first height
+  margin-bottom: 20px;
+
+  // increase calendar height at wider screens
+  @media (min-width: 768px) {
+    height: 600px;
+  }
+}

--- a/app/views/pages/calendar.html.erb
+++ b/app/views/pages/calendar.html.erb
@@ -1,7 +1,6 @@
 <div class="container bs-docs-container role="main">
-  <h1 class="calendar-header">Events<small class="calendar-subheader hidden-xs">What's happening this month?</small></h1>
+  <h1 class="calendar-header">Events<small class="calendar-subheader">What's happening this month?</small></h1>
   <div class="calendar-container">
     <iframe class="calendar-iframe" src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;wkst=1&amp;bgcolor=%2366cccc&amp;src=fmnkpvclferu6r3v63al1g2em0%40group.calendar.google.com&amp;color=%23125A12&amp;ctz=America%2FNew_York" style="border-width:0" width="100%"frameborder="0" scrolling="no"></iframe>
   </div>
-  <p class="lead">Get involved with our latest events.</p>
 </div>

--- a/app/views/pages/calendar.html.erb
+++ b/app/views/pages/calendar.html.erb
@@ -1,12 +1,7 @@
-<div class="container bs-docs-container">
-  <div class="row">
-    <div class="col-md-12" role="main">
-        <h1 id="download" class="page-header">Here's what's coming up.</h1>
-        <p class="lead">Get involved with our latest events.
-	<p>
-	<iframe src="https://calendar.google.com/calendar/embed?src=fmnkpvclferu6r3v63al1g2em0%40group.calendar.google.com&ctz=America/New_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>	
-        </div>
-
-      </div>
-    </div>
+<div class="container bs-docs-container role="main">
+  <h1 class="calendar-header">Events<small class="calendar-subheader hidden-xs">What's happening this month?</small></h1>
+  <div class="calendar-container">
+    <iframe class="calendar-iframe" src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;wkst=1&amp;bgcolor=%2366cccc&amp;src=fmnkpvclferu6r3v63al1g2em0%40group.calendar.google.com&amp;color=%23125A12&amp;ctz=America%2FNew_York" style="border-width:0" width="100%"frameborder="0" scrolling="no"></iframe>
   </div>
+  <p class="lead">Get involved with our latest events.</p>
+</div>


### PR DESCRIPTION
Tweaked the calendar a bit for #149 :
* Centered it
* It should scale down at mobile screen sizes instead of overflowing off the screen
* Rounded border-radius and used the native Google Calendar internal CSS options to streamline the calendar appearance and remove unneeded elements (nav buttons, print button, other elements that don't look visually appealing embedded on our website)

I also added 'calendar.css.scss' file to contain the CSS rules specific to the calendar "module" - (see https://smacss.com) and imported the module SASS file in the application.css.scss manifest file.  If anyone else is big on SASS optimization, it might be worth looking into breaking out the entire app's CSS styles into a modular system similar to SMACSS and/or BEM-style naming conventions.

Moving on to #170, I'd like to add a form (maybe directly between the header and the calendar?) with text similar to what @hollomancer had in d888efef9923 - something like  "Get involved - suggest an event to add:" followed by inputs allowing the user to suggest Event Name, Date/Time, & Description.  Those form values could be emailed via ActionMailer to someone who has write permissions on the Google Calendar, who would evaluate the submission and add it to the calendar.

