### PR TITLE
Invitation email tests 155 and email registration confirmation

### DIFF
--- a/lib/slack/client.rb
+++ b/lib/slack/client.rb
@@ -3,12 +3,14 @@ require "net/http"
 module Slack
   INVITE_PATH = '/api/users.admin.invite'.freeze
   POST_MESSAGE_PATH = '/api/chat.postMessage'.freeze
+  USERS_LIST_PATH = '/api/users.list'.freeze
   BOT_USERNAME = 'OpCodeBot'.freeze
 
   class Client
     RequestFailed = Class.new(StandardError)
     InviteFailed = Class.new(StandardError)
     PostMessageFailed = Class.new(StandardError)
+    FetchUsersListFailed = Class.new(StandardError)
 
     attr_reader :domain
 
@@ -51,6 +53,19 @@ module Slack
       raise PostMessageFailed.new(body.to_s)
     end
 
+    def fetch_users_list(presence: 0)
+      body = send_api_request(
+        to: USERS_LIST_PATH,
+        payload: {
+          token:    @token,
+          presence: presence
+        }
+      )
+
+      return body if body['ok'] == true || body['ok'] == 'true'
+      raise FetchUsersListFailed.new(body.to_s)
+    end
+
     private
 
     def send_api_request(to:, payload:)
@@ -63,7 +78,7 @@ module Slack
 
       raise RequestFailed.new("HTTP status code: #{res.code}") unless res.is_a?(Net::HTTPSuccess)
 
-      body = JSON.parse(res.body)
+      JSON.parse(res.body)
     end
   end
 end

--- a/lib/slack/utils.rb
+++ b/lib/slack/utils.rb
@@ -1,0 +1,26 @@
+﻿require 'slack/client'
+
+module Slack
+  class Utils
+
+    def email_is_registered? email
+      users_list = client.fetch_users_list
+      users_list['members'].each do |m|
+        return true if m['profile']['email'] == email
+      end
+      false
+    end
+
+    def client
+      @slack_client ||= set_client
+    end
+
+    private
+
+      def set_client
+        Slack::Client.new \
+          subdomain: ENV["SLACK_DOMAIN"],
+          token:     ENV["SLACK_TOKEN"]
+      end
+  end
+end

--- a/lib/slack/utils.rb
+++ b/lib/slack/utils.rb
@@ -1,9 +1,9 @@
 ﻿require 'slack/client'
 
 module Slack
+  # Utilities class for running methods and discovery on Client
   class Utils
-
-    def email_is_registered? email
+    def email_is_registered?(email)
       users_list = client.fetch_users_list
       users_list['members'].each do |m|
         return true if m['profile']['email'] == email
@@ -17,10 +17,10 @@ module Slack
 
     private
 
-      def set_client
-        Slack::Client.new \
-          subdomain: ENV["SLACK_DOMAIN"],
-          token:     ENV["SLACK_TOKEN"]
-      end
+    def set_client
+      Slack::Client.new \
+        subdomain: ENV['SLACK_DOMAIN'],
+        token:     ENV['SLACK_TOKEN']
+    end
   end
 end

--- a/spec/lib/slack_client_test.rb
+++ b/spec/lib/slack_client_test.rb
@@ -81,4 +81,32 @@ describe Slack::Client do
       end.to raise_error(Slack::Client::RequestFailed)
     end
   end
+
+  describe 'fetching users.list' do
+    before(:all) do
+      @fetch_url = URI.join(
+        "https://#{@slack_client.domain}",
+        Slack::USERS_LIST_PATH).to_s
+    end
+
+    it 'returns true if all is well' do
+      stub_request(:post, /#{Regexp.quote(@fetch_url)}.*/).to_return(
+        status: 200, body: '{"ok": true}', headers: {}
+      )
+
+      expect(@slack_client.fetch_users_list['ok']).to equal true
+    end
+
+    it 'returns a user count of 1 with one slack member' do
+      stub_request(:post, /#{Regexp.quote(@fetch_url)}.*/).to_return(
+        status: 200,
+        body: '{"ok":true,
+               "members": [ { "profile": { "email": "test@example.com" } } ]
+        }',
+        headers: {}
+      )
+
+      expect(@slack_client.fetch_users_list['members'].count).to equal 1
+    end
+  end
 end

--- a/spec/lib/slack_utils_test.rb
+++ b/spec/lib/slack_utils_test.rb
@@ -37,8 +37,3 @@ describe Slack::Utils do
     end
   end
 end
-
-
-
-
-

--- a/spec/lib/slack_utils_test.rb
+++ b/spec/lib/slack_utils_test.rb
@@ -27,11 +27,13 @@ describe Slack::Utils do
     end
 
     it 'returns true if email is a member email' do
-      expect(@slack_utils.email_is_registered?('second@example.com')).to equal true
+      check = @slack_utils.email_is_registered?('second@example.com')
+      expect(check).to equal true
     end
 
     it 'returns false if email is not a member email' do
-      expect(@slack_utils.email_is_registered?('false@example.com')).to equal false
+      check = @slack_utils.email_is_registered?('false@example.com')
+      expect(check).to equal false
     end
   end
 end

--- a/spec/lib/slack_utils_test.rb
+++ b/spec/lib/slack_utils_test.rb
@@ -1,0 +1,42 @@
+﻿require 'rails_helper'
+require 'slack/utils'
+
+describe Slack::Utils do
+  # Set up Sclack::Client
+  before(:all) do
+    @slack_utils = Slack::Utils.new()
+  end
+
+  describe 'confirming email is registered' do
+    before(:all) do
+      @fetch_url = URI.join(
+        "https://#{@slack_utils.client.domain}",
+        Slack::USERS_LIST_PATH).to_s
+    end
+
+    before(:each) do
+      stub_request(:post, /#{Regexp.quote(@fetch_url)}.*/).to_return(
+        status: 200,
+        body: '{"ok":true,
+               "members": [ { "profile": { "email": "first@example.com" } },
+                            { "profile": { "email": "second@example.com" } },
+                            { "profile": { "email": "third@example.com" } } ]
+        }',
+        headers: {}
+      )
+    end
+
+    it 'returns true if email is a member email' do
+      expect(@slack_utils.email_is_registered?('second@example.com')).to equal true
+    end
+
+    it 'returns false if email is not a member email' do
+      expect(@slack_utils.email_is_registered?('false@example.com')).to equal false
+    end
+  end
+end
+
+
+
+
+


### PR DESCRIPTION
2 commits here. One for adding a fetch method in Slack Client class and one for adding a Slack Utils class for operating on Slack information.

The method added to the Utils class is email_is_registered?

This doesn't completely solve the problem due to the necessities of external automations for an automatic email registration upon receipt but introduces a couple of useful methods.