### PR TITLE
Add Thinkful to the list of schools

### DIFF
--- a/app/views/pages/codeschools.html.erb
+++ b/app/views/pages/codeschools.html.erb
@@ -263,6 +263,16 @@
         <hr>
 
         <address>
+          <a href="http://www.thinkful.com/">
+          <strong>Thinkful (Online, HQ in NYC)</strong><br></a>
+          304 Hudson St.</br>
+          5th floor</br>
+          New York, NY 10013<br>
+        </address>
+
+        <hr>
+
+        <address>
           <a href="http://tradecrafted.com/">
             <strong>Tradecraft</strong><br></a>
             New York, NY 10004<br>


### PR DESCRIPTION
Thinkful is a fully online program with headquarters in NYC.