### PR TITLE
adds node summit, separates upcoming and past conferences

### DIFF
--- a/app/views/pages/scholarships.html.erb
+++ b/app/views/pages/scholarships.html.erb
@@ -44,10 +44,16 @@
 
         <h2>Software conference scholarships</h2>
         <p class="lead">We are proud to partner with Ruby on Ales and GitHub, respectively, to introduce more transitioning military, citizen-soldiers, veterans and their families to software development through conferences. To apply, send our Scholarship Chair, Nell Shamrell-Harrington, a direct message on Slack with 2-3 sentences on your interest. Upcoming 2016 software conferences:</p>
+        <h3>Upcoming</h3>
         <ul>
           <li><p class="lead"><a href="http://www.osfeels.com/">Open Source & Feelings</a>, Seattle, WA, July 22-23, 2016</li></p>
+          <li><p class="lead"><a href="http://nodesummit.com/">Node Summit</a>, San Francisco, CA, July 27-28, 2016</li></p>
           <li><p class="lead"><a href="https://www.codeonthebeach.com/">Code on the Beach</a>, Atlantic Beach, FL, August 12-14, 2016</li></p>
           <li><p class="lead"><a href="https://360idev.com/">360iDev</a>, August 21-24, 2016</li></p>
+        </ul>
+        <br />
+        <h3>Past</h3>
+        <ul>
           <li><p class="lead"><a href="http://codeconf.com">CodeConf</a>, Los Angeles, June 27-29, 2016</li></p>
           <li><p class="lead"><a href="http://git-merge.com">GitMerge</a>, New York City, April 5, 2016</li></p>
           <li><p class="lead"><a href="http://ruby.onales.com">Ruby on Ales</a>, March 31 & April 1, 2016</li></p>


### PR DESCRIPTION
Adds Node Summit to the scholarship page.

Also separates the list of conferences into two lists - upcoming and past