### PR TITLE
Update to new.html.erb

### DIFF
--- a/app/views/veterans/registrations/new.html.erb
+++ b/app/views/veterans/registrations/new.html.erb
@@ -4,7 +4,7 @@
       <p class="lead">
         In the United States over 200,000 computing jobs open annually and 30,000 are filled by computer science undergraduates.
         That number is expected to rise to 1.2 million by 2020. Meanwhile, we have 250,000 U.S. military personnel that exit the service annually,
-        some due to sequestration. Veterans already comprise the highest unemployment across the country, over 722,000 of us.
+        some due to sequestration. Thousands of veterans are unemployed across the country with over <a href="http://www.bls.gov/news.release/pdf/vet.pdf">495,000 unemployed veterans</a> as of 2015 according to the Bureau of Labor Statistics.
         </br>
         When you join our ranks you'll be joining our growing military veterans coding community. In <a href="http://operation-code.slack.com/">Slack</a>,
         you'll network, share resources, find job opportunities, get help with your code, and become eligible for conference scholarships and coding 

--- a/app/views/veterans/registrations/new.html.erb
+++ b/app/views/veterans/registrations/new.html.erb
@@ -4,7 +4,7 @@
       <p class="lead">
         In the United States over 200,000 computing jobs open annually and 30,000 are filled by computer science undergraduates.
         That number is expected to rise to 1.2 million by 2020. Meanwhile, we have 250,000 U.S. military personnel that exit the service annually,
-        some due to sequestration. Thousands of veterans are unemployed across the country with over <a href="http://www.bls.gov/news.release/pdf/vet.pdf">495,000 unemployed veterans</a> as of 2015 according to the Bureau of Labor Statistics.
+        some due to sequestration. Hundreds of thousands of veterans are unemployed across the country with over <a href="http://www.bls.gov/news.release/pdf/vet.pdf">495,000 unemployed veterans</a> as of 2015 according to the Bureau of Labor Statistics.
         </br>
         When you join our ranks you'll be joining our growing military veterans coding community. In <a href="http://operation-code.slack.com/">Slack</a>,
         you'll network, share resources, find job opportunities, get help with your code, and become eligible for conference scholarships and coding 


### PR DESCRIPTION
Updated total veteran unemployment with source from BLS. Also rewrote the sentence because "Veterans already comprise the highest unemployment across the country" is factually incorrect. The veteran unemployment rate was lower than the total US unemployment rate in 2015.