### PR TITLE
Update copy on mentorship page

### DIFF
--- a/app/views/pages/mentorship.html.erb
+++ b/app/views/pages/mentorship.html.erb
@@ -1,25 +1,11 @@
 <div class="container">
   <div class="row">
     <div class="col m12" role="main">
-        <h3 id="download">Software Mentor Protégé Program</h3>
+        <h3 id="download">Software Mentorship Program</h3>
         <h5>Program Overview</h5>
-        <p>Operation Code's Software Mentorship Program connects transitioning military, citizen-soldiers, veterans and their families of all levels with professional software developers for life-long learning and understanding. Paired online in our peer-to-peer learning environment, you can select any programming language/stack of your choice, including:</p>
-          <ul>
-            <li>Android</li>
-            <li>C Sharp</li>
-            <li>Ember</li>
-            <li>Go</li>
-            <li>HTML</li>
-            <li>iOS</li>
-            <li>Java</li>
-            <li>JavaScript</li>
-            <li>PHP</li>
-            <li>Python</li>
-            <li>Ruby</li>
-            <li>Static-Sites, including Jekyll, Middleman, et</li>
-          </ul></p>
+        <p>Operation Code's Software Mentorship Program connects transitioning military, citizen-soldiers, veterans and their families with professional software developers for life-long learning and understanding. Paired online in our peer-to-peer learning environment, you can select any programming language/stack of your choice.</p>
 
-        <p>Our Software Mentor Protégé Program is designed to get the military veterans community, connected, networked, sharing code and supporting each other on the pursuit of becoming software developers. Additionally, we have a thriving <a href="https://operation-code.slack.com/messages/free-code-camp/">#free-code-camp</a> study group, and location-based communities, from <a href="https://operation-code.slack.com/messages/seattle/">#Seattle</a> to <a href="https://operation-code.slack.com/messages/washingtondc/">#washingtondc</a> to meet others locally in your area and organize <a href="http://meetup.com/operationcode/">Operation Code meetups</a>.</p>
+        <p>The Program is designed to support your pursuit of becoming a software developer. Additionally, we have a thriving <a href="https://operation-code.slack.com/messages/free-code-camp/">#free-code-camp</a> study group, and location-based communities, from <a href="https://operation-code.slack.com/messages/seattle/">#Seattle</a> to <a href="https://operation-code.slack.com/messages/washingtondc/">#washingtondc</a> to meet others locally in your area and organize <a href="http://meetup.com/operationcode/">Operation Code meetups</a>.</p>
 
         <div class="video-container">
           <iframe src="https://player.vimeo.com/video/125189103" width="700" height="481" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>


### PR DESCRIPTION
Making it more concise so the information is more digestible. For example, we already say folks can choose any programming language/stack of their choice so just clutters the page to include an unordered list of some of their options. Also, it makes more sense to simply refer to the program as our Software Mentorship Program instead of the Software Mentor Protege program since we already call it the software mentorship program on the homepage, in the nav menu and in the copy.