### PR TITLE
Fixed broken Slack link on FAQ > "What are the hours of operation for Operation Code?"

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,12 +13,11 @@
 </ul>
 
 <ul id="programs-and-services" class="dropdown-content">
-  <li><%= link_to 'Software Mentorship', mentorship_path %></li>
+  <li><%= link_to 'Code Schools', code_schools_path %></li>
   <li><%= link_to 'Scholarship Program', scholarships_path %></li>
+  <li><%= link_to 'Software Mentorship', mentorship_path %></li>
   <li><%= link_to 'Employer Services', employers_path %></li>
   <li><%= link_to 'Web Application Development', deploy_path %></li>
-  <li role="separator" class="divider"></li>
-  <li><%= link_to 'Code Schools', code_schools_path %></li>
 </ul>
 
 <ul id="Donate" class="dropdown-content">

--- a/config/faqs.yml
+++ b/config/faqs.yml
@@ -37,7 +37,7 @@ general:
                 We aim to turn these numbers around.
               </p>
   - question: What are the hours of operation for Operation Code?
-    answer:   "Operation Code is different in that we don't have regular business office hours. The team can usually be found in our <a href='operation-code.slack.com'>Slack channel</a>, or <a href='https://github.com/OperationCode/operationcode'>GitHub</a> fixing bugs and implementing new features."
+    answer:   "Operation Code is different in that we don't have regular business office hours. The team can usually be found in our <a href='http://operation-code.slack.com'>Slack channel</a>, or <a href='https://github.com/OperationCode/operationcode'>GitHub</a> fixing bugs and implementing new features."
   - question: How can I help if I can't afford to donate to Operation Code?
     answer:   'In addition to requiring financial support, we also need volunteers and interns. The larger our community, the more we can spread the word about our work. Please sign up for our <a href="http://operationcode.us10.list-manage2.com/subscribe?u=0ab8e2b2d6c6608926c4f17d6&id=809aaab2df">SITREPs</a> and share it with your friends. Also, remember that every <a href="/donate">donation</a>, no matter how modest, brings us closer to our goals.'
   - question: I would like to receive Operation Code updates and news. How can I receive these communications?


### PR DESCRIPTION
Updated the faqs.yml link to slack on line 39. Changed Slack link from `operation-code.slack.com` to `http://operation-code.slack.com`. It was missing `http://` to open as external link.

This closes issue #523 .