### PR TITLE
Specificity for bullets on FAQ

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -75,3 +75,16 @@ $opcode-green: #26a69a;
   line-height: 64px;
   padding: 0 30px;
 }
+
+// fixes bullets for FAQs
+.faqbullet li {
+  list-style: initial;
+  list-style-type: circle;
+  margin-left: 5%;
+}
+
+// adds padding to newline
+.pad-left {
+  padding-left: 3%;
+}
+

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,12 +13,11 @@
 </ul>
 
 <ul id="programs-and-services" class="dropdown-content">
-  <li><%= link_to 'Software Mentorship', mentorship_path %></li>
+  <li><%= link_to 'Code Schools', code_schools_path %></li>
   <li><%= link_to 'Scholarship Program', scholarships_path %></li>
+  <li><%= link_to 'Software Mentorship', mentorship_path %></li>
   <li><%= link_to 'Employer Services', employers_path %></li>
   <li><%= link_to 'Web Application Development', deploy_path %></li>
-  <li role="separator" class="divider"></li>
-  <li><%= link_to 'Code Schools', code_schools_path %></li>
 </ul>
 
 <ul id="Donate" class="dropdown-content">

--- a/config/faqs.yml
+++ b/config/faqs.yml
@@ -29,12 +29,13 @@ general:
     answer:   >
               As President Lincoln once said, “With malice toward none, with charity for all, with firmness in the right as God gives us to see the right, let us strive on to finish the work we are in, to bind up the nation's wounds, to care for him who shall have borne the battle and for his widow and his orphan...”
               <p>At Operation Code, we believe it is our moral obligation to ensure the men and women who are serving/served in our U.S. military should not be left behind in the new skills and knowledge economy. These numbers speak for themselves:
-                <ul>
+                <ul class="faqbullet">
                   <li>high veterans unemployment/underemployment</li>
                   <li>high veterans suicide rate</li>
                   <li>high veterans homeless rate</li>
                 </ul>
-                We aim to turn these numbers around.
+                <br>
+              <span class= "pad-left">We aim to turn these numbers around.</span>
               </p>
   - question: What are the hours of operation for Operation Code?
     answer:   "Operation Code is different in that we don't have regular business office hours. The team can usually be found in our <a href='http://operation-code.slack.com'>Slack channel</a>, or <a href='https://github.com/OperationCode/operationcode'>GitHub</a> fixing bugs and implementing new features."


### PR DESCRIPTION
I added a class to have the bullets appear properly. This closes #522.

**From**
<img width="867" alt="screen shot 2016-10-05 at 5 48 34 pm" src="https://cloud.githubusercontent.com/assets/17578236/19132978/11976136-8b24-11e6-85ac-323aa3043cc0.png">

**To**

<img width="958" alt="screen shot 2016-10-05 at 5 48 45 pm" src="https://cloud.githubusercontent.com/assets/17578236/19132982/184dec5c-8b24-11e6-868f-0da9edfd1fcb.png">

