### PR TITLE
Added target of Blog Link

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -46,7 +46,7 @@
         <li><a class="dropdown-button" href="#!" data-constrainwidth="false" data-beloworigin="true" data-activates="Donate">Donate<i class="material-icons right">arrow_drop_down</i></a></li>
 
         <li><%= link_to 'Success Stories', success_stories_path %></li>
-        <li><%= link_to 'Blog', 'https://medium.com/operation-code' %></li>
+        <li><%= link_to 'Blog', 'https://medium.com/operation-code', :target => "_blank" %></li>
         <% if veteran_signed_in? %>
           <li><%= link_to 'Profile', profile_path %></li>
           <li><%= link_to 'Sign Out', destroy_veteran_session_path, method: :delete %></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -46,7 +46,7 @@
         <li><a class="dropdown-button" href="#!" data-constrainwidth="false" data-beloworigin="true" data-activates="Donate">Donate<i class="material-icons right">arrow_drop_down</i></a></li>
 
         <li><%= link_to 'Success Stories', success_stories_path %></li>
-        <li><%= link_to 'Blog', 'https://medium.com/operation-code', :target => "_blank" %></li>
+        <li><%= link_to 'Blog', 'https://medium.com/operation-code', target: '_blank' %></li>
         <% if veteran_signed_in? %>
           <li><%= link_to 'Profile', profile_path %></li>
           <li><%= link_to 'Sign Out', destroy_veteran_session_path, method: :delete %></li>


### PR DESCRIPTION
added a target of blank to the blog link for issue #496 

WIth the desire of keeping users in the operationcode application, the fact that the blog currently resides on the medium platform makes the best UX choice to have that link open a new tab/window.  Blank target lets the user's browser make that choice.
