### PR TITLE
Add video-container to respond Vimeo embed

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -192,9 +192,9 @@
         We're on a mission to enable new career paths for military, veterans 
         and their families in software development and coding.
       </h5>
-      <!-- This class makes the video disappear. ¯\_(ツ)_/¯ Disabling for now.
-      <div class="video-container">-->
-      <div>
+    </div>
+    <div class="row center">
+      <div class="video-container">
         <iframe src="https://player.vimeo.com/video/124866675" width="700" height="481"
           frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen>
         </iframe>


### PR DESCRIPTION
Corrected issue where classes on Why Operation Code subtitle caused a layout bug for the .video-container element below it.

Addresses #562.