### PR TITLE
Tell the contributor to start their redis server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ Redis is used to manage asynchronous jobs. This step is optional and only requir
 * [Install redis](http://redis.io/download)
 * Or on a mac via homebrew: `brew install redis`
 * Redis is not supported on Windows.
+* Start your redis server: `redis-server`
 
 ### Bundler
 Bundler manages libraries (gems) and their dependencies.


### PR DESCRIPTION
When setting up my development environment, I was presented with the attached error. I hadn't started my redis server prior to starting my rails server. This PR will add the instructions to the start the redis server after installing it.

<img width="1038" alt="screenshot 2016-11-12 23 45 23" src="https://cloud.githubusercontent.com/assets/22661110/20243741/539d7300-a932-11e6-95e8-cc069061700b.png">
