### PR TITLE
Style the flash message and separate color variables to separate partial

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -1,0 +1,7 @@
+$white: #ffffff;
+$alert-red: #ee6e73;
+$gray: #777777;
+$black: #000000;
+
+// Operation Code colors
+$opcode-green: #26a69a;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,6 +1,7 @@
 //= require leaflet
 
 //@import "active_admin";
+@import "colors";
 @import "calendar";
 @import "map";
 @import "deploy";
@@ -16,7 +17,7 @@
 }
 
 nav ul li a {
-  color: #777;
+  color: $gray;
 }
 
 // Fix opacity for better text readability
@@ -26,23 +27,23 @@ nav ul li a {
 
 // Fix vertical alignment in main page slider
 .slider .slides li .caption {
-  color: #fff;
+  color: $white;
   left: 10%;
   opacity: 0;
   position: absolute;
   top: 40% !important;
   width: 80%;
-  text-shadow: 1px 1px 7px #000000;
+  text-shadow: 1px 1px 7px $black;
   @media only screen and (min-width: 992px){
     left: 15%;
     width: 65%;
   }
   h3{
     font-size: 2.2rem;
-    line-height:120%;
+    line-height: 120%;
     @media only screen and (min-width: 992px){
       font-size: 2.92rem;
-      line-height:110%;
+      line-height: 110%;
     }
   }
 }
@@ -67,8 +68,6 @@ i.fa.medium {
   word-wrap: normal;
 }
 
-
-$opcode-green: #26a69a;
 .opcode-green { background-color: $opcode-green; }
 .opcode-green-text { color: $opcode-green; }
 
@@ -93,3 +92,15 @@ $opcode-green: #26a69a;
   padding-left: 3%;
 }
 
+.alert {
+  background-color: $alert-red;
+  color: $white;
+  font-size: 10px;
+  left: 50%;
+  padding: 5px 20px;
+  position: fixed;
+  text-align: center;
+  top: 6vh;
+  transform: translateX(-50%);
+  z-index: 997;
+}


### PR DESCRIPTION
This PR will style the flash message to be a little more intentional. I have also separated the color variables in `application.css.scss` to a new partial, `_colors.scss`. This should allow us to maintain a better brand usage.

Relates to [#296](https://github.com/OperationCode/operationcode/issues/296). 

### Old Screenshot
<img width="678" alt="screenshot 2016-11-12 23 50 55" src="https://cloud.githubusercontent.com/assets/22661110/20243791/d910484e-a934-11e6-876d-2460fa3622ef.png">

### New Screenshot
<img width="666" alt="screenshot 2016-11-13 00 04 40" src="https://cloud.githubusercontent.com/assets/22661110/20243792/dd8c532c-a934-11e6-807e-e8ee69b09c1d.png">
