### PR TITLE
Added links to code of conduct and mentorship

### DIFF
--- a/app/views/user_mailer/welcome.html.erb
+++ b/app/views/user_mailer/welcome.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Welcome to Operation Code! You've just joined a community of <%= Veteran.count.round(-2) %>+ veterans in the same shoes.<br />
+  Welcome to Operation Code! You've just joined a community of <%= Veteran.count.round(-2) %>+ coders, who are all looking to further their skills and careers in software development!<br />
   You can set your password <%= link_to "here", edit_veteran_registration_url(@veteran) %>.
 </p>
 
@@ -7,11 +7,13 @@
 <p>
   Check your email for an invite to our Operation Code Slack channel (<a href="https://operation-code.slack.com">https://operation-code.slack.com</a>).<br />
   Slack is where we communicate online and across the globe with each other to ask questions, collaborate, and share information. Once in Slack (you'll probably want to download the app), introduce yourself in the #general channel. An example could be: <br />
-  Hi all. My name is David. I'm from Washington and I'm interested in webdev!
+  "Hi all. My name is David. I'm from Washington and I'm interested in webdev!"
+  Please read our <a href="http://bit.ly/oc-code-of-conduct">Code of Conduct</a>, as well.
 </p>
 
 <p>
   The Operation Code website uses Ruby On Rails. If you want to dive in and help you can get started by reading our <a href="https://github.com/OperationCode/operationcode/blob/master/CONTRIBUTING.md">docs</a>, or asking around in the #operation-code-dot-org slack channel.
+  If you're interested in our mentorship program, fill out our application form as either a <a href="http://bit.ly/oc-mentor-enrollment">mentor</a> or <a href="http://bit.ly/mentorship-signup">mentee</a>, also!
 </p>
 
 <p>Again, welcome aboard, and don't forget to follow and share Operation Code on <a href="https://twitter.com/operation_code">Twitter</a> and <a href="https://facebook.com/operationcode.org">Facebook</a>.</p>
@@ -22,4 +24,4 @@
   <a href="http://twitter.com/davidcmolina">@davidcmolina</a>
 </p>
 
-<p>P.S If you do not receive an invite from Slack within 2 hours please <a href="mailto:staff@operationcode.org">email our staff</a>, or ping me on Twitter</p>
+<p>P.S. - If you do not receive an invite from Slack within 2 hours, please <a href="mailto:staff@operationcode.org">email our staff</a>, or ping us on Twitter at @operation_code.</p>


### PR DESCRIPTION
Welcome emailer has a few copy fixes, and includes direct links to our mentorship forms and code of conduct.