### PR TITLE
Add GitHub free online training to the contributing markdown file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ So, you want to learn how to program? Contributing to Operation Code is a great 
 
   * [Install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 
+
+  ### GitHub
+  GitHub is a web-based repository where the Operation Code website's source code is hosted.  GitHub utilizes Git's version control system and allows other developers to contribute to the codebase.  If you're unfamiliar with GitHub, we recommend running through the free online training resources they offer.
+
+  * [GitHub Training](https://services.github.com/training/)   
+
   ### PostgreSQL
   PostgreSQL is an open source Object-Relational database. This stores all of **Operation Code**'s data.
 


### PR DESCRIPTION
I added a short paragraph/blurb to CONTRIBUTING.md describing:
* What GitHub is
* Where to find some quality free online training for it

It seems like there are recurring questions from new members (in Slack) on what GitHub is and how to use it.  The current CONTRIBUTING.md briefly explains Git, but not GitHub.  The difference btw/ Git <-> GitHub also seems to be a point of confusion for some.  Hopefully this can clear some of that up.

The training was recommended in the Slack channel by one of of our members who works for GitHub.

If anyone else has ideas on how to improve the wording on this, please edit or comment on this PR.