### PR TITLE
Remove zipcode from signup

### DIFF
--- a/app/views/veterans/registrations/_form.html.erb
+++ b/app/views/veterans/registrations/_form.html.erb
@@ -2,7 +2,7 @@
   <%= devise_error_messages! %>
 
   <div class='row'>
-    <div class='col m12 offset-s1 offset-m2'>
+    <div class='col m12 offset-s0 offset-m3'>
       <span class='input-field col m3'>
         <%= f.email_field :email, autofocus: true, placeholder: 'email' %>
       </span>

--- a/app/views/veterans/registrations/_form.html.erb
+++ b/app/views/veterans/registrations/_form.html.erb
@@ -7,10 +7,6 @@
         <%= f.email_field :email, autofocus: true, placeholder: 'email' %>
       </span>
 
-      <span class='input-field col m2'>
-        <%= f.text_field :zip, placeholder: 'zip code', class: 'form-control', maxlength: 5 %>
-      </span>
-
       <span class="input-field col m1 s5">
         <%= f.submit 'Teach me to code!', class: 'btn btn-default' %>
       </span>


### PR DESCRIPTION
I started this to address https://github.com/OperationCode/operationcode/issues/570 but before I realized that there needs to be a landing page after signup first 😅 


I'll leave this here in case there's any reason to remove the zip code before that goes into place.  Also the main 'change' aside from removing the field is to adjust the columns to re-center it.