### PR TITLE
Fix notification when signing up (or really any flash)

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -94,18 +94,21 @@ i.fa.medium {
   padding-left: 3%;
 }
 
+
+#alert-section {
+  z-index: 997;
+  // make sure to display below where the navbar is display
+  top: $navbar-height;
+  position: fixed;
+  left: 50%;
+}
 .alert {
   background-color: $alert-red;
-  color: $white;
   font-size: 10px;
-  left: 50%;
-  padding: 5px 20px;
-  margin-top: $navbar-height; // push down below navbar
-  position: fixed;
   text-align: center;
-  top: 6vh;
+  color: $white;
+  padding: 5px 20px;
   transform: translateX(-50%);
-  z-index: 997;
 }
 
 // darkens placeholder text

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -100,7 +100,7 @@ i.fa.medium {
   font-size: 10px;
   left: 50%;
   padding: 5px 20px;
-  margin-top: $navbar-height;
+  margin-top: $navbar-height; // push down below navbar
   position: fixed;
   text-align: center;
   top: 6vh;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -95,13 +95,14 @@ i.fa.medium {
 }
 
 
-#alert-section {
-  z-index: 997;
+.alert-section {
+  left: 50%;
+  position: fixed;
   // make sure to display below where the navbar is display
   top: $navbar-height;
-  position: fixed;
-  left: 50%;
+  z-index: 997;
 }
+
 .alert {
   background-color: $alert-red;
   font-size: 10px;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -7,9 +7,11 @@
 @import "deploy";
 @import "success_stories";
 
+$navbar-height: 64px;
+
 // Match logo to size of navbar
 .navbar-fixed .nav-wrapper .brand-logo img {
-  height: 64px;
+  height: $navbar-height;
 }
 
 .navbar-fixed .nav-wrapper.container {
@@ -98,6 +100,7 @@ i.fa.medium {
   font-size: 10px;
   left: 50%;
   padding: 5px 20px;
+  margin-top: $navbar-height;
   position: fixed;
   text-align: center;
   top: 6vh;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,9 +30,11 @@
   <body>
     <%= render 'layouts/header' %>
 
-    <% flash.each do |name, msg| %>
-      <%= content_tag(:div, msg, class: "alert alert-info") %>
-    <% end %>
+    <div class="section" id="alert-section">
+      <% flash.each do |name, msg| %>
+        <%= content_tag(:div, msg, class: "alert alert-info") %>
+      <% end %>
+    </div>
 
     <%= yield %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
   <body>
     <%= render 'layouts/header' %>
 
-    <div class="section" id="alert-section">
+    <div class="alert-section">
       <% flash.each do |name, msg| %>
         <%= content_tag(:div, msg, class: "alert alert-info") %>
       <% end %>


### PR DESCRIPTION
This is one possible fix for https://github.com/OperationCode/operationcode/issues/646

![](https://cl.ly/3H0n361H342U/Image%202017-02-24%20at%204.23.11%20PM.png)

Another problem I observed is when there are multiple alerts on a page (by having, say, both `flash[:notice]` and `flash[:error]`). The `.alert` style uses a z-axis, so the multiple alerts would be positioned on top of each other, and all but the first would be hidden.

![](https://cl.ly/3b1d2o0H373k/Image%202017-02-24%20at%204.26.36%20PM.png)

This PR solves both by putting the alerts into it's own `section` (but I guess it could have been a `container` too). This allows the section to be positioned (with z axis, offset from the top), and multiple alerts can go inside