### PR TITLE
Change the readme to say that you will need to run the redis server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ So, you want to learn how to program? Contributing to Operation Code is a great 
     * [Detailed Windows Installation Instructions](https://wiki.postgresql.org/wiki/Detailed_installation_guides#Windows)
 
   ### Redis
-  Redis is used to manage asynchronous jobs. This step is optional, and it is only required if you are working on an area that uses `ActiveJob`.
+  Redis is used to manage asynchronous jobs. You will need to run your Redis server in order for normal operation of the main app server.
+
+  If you're working on an area that uses `ActiveJob` you'll need to work with Redis more directly.
 
   * [Install Redis](http://redis.io/download)
   * If you are using a Mac, you can install it through Homebrew: `brew install redis`


### PR DESCRIPTION
@hollomancer In setting up the project to do work I had to run the redis server to avoid fatal errors on the main server. The documentation suggests that you don't have to run the redis server unless you're working on something dealing with `ActiveJob`.  This PR changes the wording a little to say you need it running but will deal with it more directly if you're working on an active job aspect of the project. 