### PR TITLE
Prevent Travis CI from deleting Jekyll build artifacts #670

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ deploy:
     repo: OperationCode/operationcode
   run:
     "rake db:migrate"
+  skip_cleanup: true
 notifications:
   slack:
     secure: iT5O6nPXUfThuPLhLXY1q6iNPrJfXxwv78ZynDiZZ2HjUqk98F7LTLY4dAXabbPL2w4hY9YcE8gTXch5n+eyjIaCSNHiR6VMJuxdhiw7uolAy5F71rEMyhNmZbe7X+lqNTp5GpoBUU2oCrT3Hh30lE8Z3c1XrQ+hvm0vh7Y1hXs=


### PR DESCRIPTION
Changed .travis.yml to prevent Travis CI from resetting the working directory and deleting all changes made during the build (the output files from the Jekyll build).