### PR TITLE
Revert header blog link to point to Medium

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -32,7 +32,7 @@
         <li><a class="dropdown-button" href="#!" data-constrainwidth="false" data-beloworigin="true" data-activates="programs-and-services">What We Do<i class="material-icons right">arrow_drop_down</i></a></li>
 
         <li><%= link_to 'Success Stories', success_stories_path %></li>
-        <li><%= link_to 'Blog', '/blog', target: '_blank' %></li>
+        <li><%= link_to 'Blog', 'https://medium.com/operation-code', target: '_blank' %></li>
         <li>
           <a class="btn" href="https://donorbox.org/operationcode"
             data-constrainwidth="false" data-beloworigin="true" data-activates="Donate">Donate</a>


### PR DESCRIPTION
While we work through the issues of getting the Jekyll blog properly built w/ TravisCI & Heroku, this link should point to the working Medium blog.

When the Jekyll blog assets are deployed/served, the link can be changed to point to the `/blog` URL again.

related to #624 