### PR TITLE
Allow mentors to sign up without emailing staff@operationcode.org

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -31,7 +31,7 @@
           <li><a href="https://operationcode.threadless.com/" target="_blank">Store</a></li>
           <li><a href="https://donorbox.org/operationcode">Donate</a></li>
           <li><a href="/contribute">Open Source</a></li>
-          <li><a href="mailto:staff@operationcode.org">Software Mentorship</a>
+          <li><a href="/sign_up">Software Mentorship</a>
           <li><a href="mailto:staff@operationcode.org">Internships</a>
           <li><%= link_to 'Shop on AmazonSmile', amazon_path %></li>
         </ul>


### PR DESCRIPTION
Added this using a feature branch instead to avoid unnecessary merge commits.
I altered the Software Mentorship link under "Get Involved" to link to /sign_up. If there's going to be a new mentor sign up page (#629), this can be easily updated once that's completed.