### PR TITLE
Fixed duplicate address1 in Coder Camps entry in code_schools.yml

### DIFF
--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -518,7 +518,7 @@
 - name: Coder Camps (Scottsdale, AZ / Online)
   url: https://www.codercamps.com
   address1: 8444 N 90TH ST
-  address1: Suite 110
+  address2: Suite 110
   city: Scottsdale
   state: AZ
   zip: 85258

--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -3,7 +3,7 @@
 #- name: <School Name>
 #  url: <School URL> [optional]
 #  address1: <Address Line1>
-#  address1: <Address Line2> [optional]
+#  address2: <Address Line2> [optional]
 #  city: <School City>
 #  state: <School State !!! Must be the 2 letter state code !!!>
 #  zip: <School Zip>

--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -525,4 +525,4 @@
   va_accepted: false
   full_time:  true
   hardware_included: false
-  notes: Coder Camps offers two paths to taking a Full Stack Web Development course: a <strong>12 week</strong> full time Immersive on-campus/online program and a <strong>24 week</strong> part time Structured Online program.  Active military and veterans receive a <strong>20% discount</strong> on tuition, we are able to accept Chapter 31 & 35 benefits.
+  notes: Coder Camps offers two paths to taking a Full Stack Web Development course. A <strong>12 week</strong> full time Immersive on-campus/online program and a <strong>24 week</strong> part time Structured Online program.  Active military and veterans receive a <strong>20 percent discount</strong> on tuition, we are able to accept Chapter 31 &amp; 35 benefits.

--- a/config/code_schools.yml
+++ b/config/code_schools.yml
@@ -502,7 +502,7 @@
   va_accepted: true
   full_time: true
   hardware_included: false
-  
+
 - name: Code Immersives (New York City, New York)
   url:  https://web1.codeimmersives.com/
   address1: 630 9th Ave
@@ -514,3 +514,15 @@
   full_time: true
   hardware_included: true
   notes: (Also see, <a href="https://web1.codeimmersives.com/students/veterans"> Veteran Student </a>.)
+
+- name: Coder Camps (Scottsdale, AZ / Online)
+  url: https://www.codercamps.com
+  address1: 8444 N 90TH ST
+  address1: Suite 110
+  city: Scottsdale
+  state: AZ
+  zip: 85258
+  va_accepted: false
+  full_time:  true
+  hardware_included: false
+  notes: Coder Camps offers two paths to taking a Full Stack Web Development course: a <strong>12 week</strong> full time Immersive on-campus/online program and a <strong>24 week</strong> part time Structured Online program.  Active military and veterans receive a <strong>20% discount</strong> on tuition, we are able to accept Chapter 31 & 35 benefits.


### PR DESCRIPTION
This is a fix to a previous PR.  I updated the second address1 to address2.  There is no issue related to this.