### PR TITLE
#278 History page converted to timeline

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,5 @@
 //= require leaflet
 //= require leaflet.markercluster
 //= require veterans
+//= require timeline
+//= require modernizr

--- a/app/assets/javascripts/modernizr.js
+++ b/app/assets/javascripts/modernizr.js
@@ -1,0 +1,1406 @@
+/*!
+ * Modernizr v2.7.1
+ * www.modernizr.com
+ *
+ * Copyright (c) Faruk Ates, Paul Irish, Alex Sexton
+ * Available under the BSD and MIT licenses: www.modernizr.com/license/
+ */
+
+/*
+ * Modernizr tests which native CSS3 and HTML5 features are available in
+ * the current UA and makes the results available to you in two ways:
+ * as properties on a global Modernizr object, and as classes on the
+ * <html> element. This information allows you to progressively enhance
+ * your pages with a granular level of control over the experience.
+ *
+ * Modernizr has an optional (not included) conditional resource loader
+ * called Modernizr.load(), based on Yepnope.js (yepnopejs.com).
+ * To get a build that includes Modernizr.load(), as well as choosing
+ * which tests to include, go to www.modernizr.com/download/
+ *
+ * Authors        Faruk Ates, Paul Irish, Alex Sexton
+ * Contributors   Ryan Seddon, Ben Alman
+ */
+
+window.Modernizr = (function( window, document, undefined ) {
+
+    var version = '2.7.1',
+
+    Modernizr = {},
+
+    /*>>cssclasses*/
+    // option for enabling the HTML classes to be added
+    enableClasses = true,
+    /*>>cssclasses*/
+
+    docElement = document.documentElement,
+
+    /**
+     * Create our "modernizr" element that we do most feature tests on.
+     */
+    mod = 'modernizr',
+    modElem = document.createElement(mod),
+    mStyle = modElem.style,
+
+    /**
+     * Create the input element for various Web Forms feature tests.
+     */
+    inputElem /*>>inputelem*/ = document.createElement('input') /*>>inputelem*/ ,
+
+    /*>>smile*/
+    smile = ':)',
+    /*>>smile*/
+
+    toString = {}.toString,
+
+    // TODO :: make the prefixes more granular
+    /*>>prefixes*/
+    // List of property values to set for css tests. See ticket #21
+    prefixes = ' -webkit- -moz- -o- -ms- '.split(' '),
+    /*>>prefixes*/
+
+    /*>>domprefixes*/
+    // Following spec is to expose vendor-specific style properties as:
+    //   elem.style.WebkitBorderRadius
+    // and the following would be incorrect:
+    //   elem.style.webkitBorderRadius
+
+    // Webkit ghosts their properties in lowercase but Opera & Moz do not.
+    // Microsoft uses a lowercase `ms` instead of the correct `Ms` in IE8+
+    //   erik.eae.net/archives/2008/03/10/21.48.10/
+
+    // More here: github.com/Modernizr/Modernizr/issues/issue/21
+    omPrefixes = 'Webkit Moz O ms',
+
+    cssomPrefixes = omPrefixes.split(' '),
+
+    domPrefixes = omPrefixes.toLowerCase().split(' '),
+    /*>>domprefixes*/
+
+    /*>>ns*/
+    ns = {'svg': 'http://www.w3.org/2000/svg'},
+    /*>>ns*/
+
+    tests = {},
+    inputs = {},
+    attrs = {},
+
+    classes = [],
+
+    slice = classes.slice,
+
+    featureName, // used in testing loop
+
+
+    /*>>teststyles*/
+    // Inject element with style element and some CSS rules
+    injectElementWithStyles = function( rule, callback, nodes, testnames ) {
+
+      var style, ret, node, docOverflow,
+          div = document.createElement('div'),
+          // After page load injecting a fake body doesn't work so check if body exists
+          body = document.body,
+          // IE6 and 7 won't return offsetWidth or offsetHeight unless it's in the body element, so we fake it.
+          fakeBody = body || document.createElement('body');
+
+      if ( parseInt(nodes, 10) ) {
+          // In order not to give false positives we create a node for each test
+          // This also allows the method to scale for unspecified uses
+          while ( nodes-- ) {
+              node = document.createElement('div');
+              node.id = testnames ? testnames[nodes] : mod + (nodes + 1);
+              div.appendChild(node);
+          }
+      }
+
+      // <style> elements in IE6-9 are considered 'NoScope' elements and therefore will be removed
+      // when injected with innerHTML. To get around this you need to prepend the 'NoScope' element
+      // with a 'scoped' element, in our case the soft-hyphen entity as it won't mess with our measurements.
+      // msdn.microsoft.com/en-us/library/ms533897%28VS.85%29.aspx
+      // Documents served as xml will throw if using &shy; so use xml friendly encoded version. See issue #277
+      style = ['&#173;','<style id="s', mod, '">', rule, '</style>'].join('');
+      div.id = mod;
+      // IE6 will false positive on some tests due to the style element inside the test div somehow interfering offsetHeight, so insert it into body or fakebody.
+      // Opera will act all quirky when injecting elements in documentElement when page is served as xml, needs fakebody too. #270
+      (body ? div : fakeBody).innerHTML += style;
+      fakeBody.appendChild(div);
+      if ( !body ) {
+          //avoid crashing IE8, if background image is used
+          fakeBody.style.background = '';
+          //Safari 5.13/5.1.4 OSX stops loading if ::-webkit-scrollbar is used and scrollbars are visible
+          fakeBody.style.overflow = 'hidden';
+          docOverflow = docElement.style.overflow;
+          docElement.style.overflow = 'hidden';
+          docElement.appendChild(fakeBody);
+      }
+
+      ret = callback(div, rule);
+      // If this is done after page load we don't want to remove the body so check if body exists
+      if ( !body ) {
+          fakeBody.parentNode.removeChild(fakeBody);
+          docElement.style.overflow = docOverflow;
+      } else {
+          div.parentNode.removeChild(div);
+      }
+
+      return !!ret;
+
+    },
+    /*>>teststyles*/
+
+    /*>>mq*/
+    // adapted from matchMedia polyfill
+    // by Scott Jehl and Paul Irish
+    // gist.github.com/786768
+    testMediaQuery = function( mq ) {
+
+      var matchMedia = window.matchMedia || window.msMatchMedia;
+      if ( matchMedia ) {
+        return matchMedia(mq).matches;
+      }
+
+      var bool;
+
+      injectElementWithStyles('@media ' + mq + ' { #' + mod + ' { position: absolute; } }', function( node ) {
+        bool = (window.getComputedStyle ?
+                  getComputedStyle(node, null) :
+                  node.currentStyle)['position'] == 'absolute';
+      });
+
+      return bool;
+
+     },
+     /*>>mq*/
+
+
+    /*>>hasevent*/
+    //
+    // isEventSupported determines if a given element supports the given event
+    // kangax.github.com/iseventsupported/
+    //
+    // The following results are known incorrects:
+    //   Modernizr.hasEvent("webkitTransitionEnd", elem) // false negative
+    //   Modernizr.hasEvent("textInput") // in Webkit. github.com/Modernizr/Modernizr/issues/333
+    //   ...
+    isEventSupported = (function() {
+
+      var TAGNAMES = {
+        'select': 'input', 'change': 'input',
+        'submit': 'form', 'reset': 'form',
+        'error': 'img', 'load': 'img', 'abort': 'img'
+      };
+
+      function isEventSupported( eventName, element ) {
+
+        element = element || document.createElement(TAGNAMES[eventName] || 'div');
+        eventName = 'on' + eventName;
+
+        // When using `setAttribute`, IE skips "unload", WebKit skips "unload" and "resize", whereas `in` "catches" those
+        var isSupported = eventName in element;
+
+        if ( !isSupported ) {
+          // If it has no `setAttribute` (i.e. doesn't implement Node interface), try generic element
+          if ( !element.setAttribute ) {
+            element = document.createElement('div');
+          }
+          if ( element.setAttribute && element.removeAttribute ) {
+            element.setAttribute(eventName, '');
+            isSupported = is(element[eventName], 'function');
+
+            // If property was created, "remove it" (by setting value to `undefined`)
+            if ( !is(element[eventName], 'undefined') ) {
+              element[eventName] = undefined;
+            }
+            element.removeAttribute(eventName);
+          }
+        }
+
+        element = null;
+        return isSupported;
+      }
+      return isEventSupported;
+    })(),
+    /*>>hasevent*/
+
+    // TODO :: Add flag for hasownprop ? didn't last time
+
+    // hasOwnProperty shim by kangax needed for Safari 2.0 support
+    _hasOwnProperty = ({}).hasOwnProperty, hasOwnProp;
+
+    if ( !is(_hasOwnProperty, 'undefined') && !is(_hasOwnProperty.call, 'undefined') ) {
+      hasOwnProp = function (object, property) {
+        return _hasOwnProperty.call(object, property);
+      };
+    }
+    else {
+      hasOwnProp = function (object, property) { /* yes, this can give false positives/negatives, but most of the time we don't care about those */
+        return ((property in object) && is(object.constructor.prototype[property], 'undefined'));
+      };
+    }
+
+    // Adapted from ES5-shim https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js
+    // es5.github.com/#x15.3.4.5
+
+    if (!Function.prototype.bind) {
+      Function.prototype.bind = function bind(that) {
+
+        var target = this;
+
+        if (typeof target != "function") {
+            throw new TypeError();
+        }
+
+        var args = slice.call(arguments, 1),
+            bound = function () {
+
+            if (this instanceof bound) {
+
+              var F = function(){};
+              F.prototype = target.prototype;
+              var self = new F();
+
+              var result = target.apply(
+                  self,
+                  args.concat(slice.call(arguments))
+              );
+              if (Object(result) === result) {
+                  return result;
+              }
+              return self;
+
+            } else {
+
+              return target.apply(
+                  that,
+                  args.concat(slice.call(arguments))
+              );
+
+            }
+
+        };
+
+        return bound;
+      };
+    }
+
+    /**
+     * setCss applies given styles to the Modernizr DOM node.
+     */
+    function setCss( str ) {
+        mStyle.cssText = str;
+    }
+
+    /**
+     * setCssAll extrapolates all vendor-specific css strings.
+     */
+    function setCssAll( str1, str2 ) {
+        return setCss(prefixes.join(str1 + ';') + ( str2 || '' ));
+    }
+
+    /**
+     * is returns a boolean for if typeof obj is exactly type.
+     */
+    function is( obj, type ) {
+        return typeof obj === type;
+    }
+
+    /**
+     * contains returns a boolean for if substr is found within str.
+     */
+    function contains( str, substr ) {
+        return !!~('' + str).indexOf(substr);
+    }
+
+    /*>>testprop*/
+
+    // testProps is a generic CSS / DOM property test.
+
+    // In testing support for a given CSS property, it's legit to test:
+    //    `elem.style[styleName] !== undefined`
+    // If the property is supported it will return an empty string,
+    // if unsupported it will return undefined.
+
+    // We'll take advantage of this quick test and skip setting a style
+    // on our modernizr element, but instead just testing undefined vs
+    // empty string.
+
+    // Because the testing of the CSS property names (with "-", as
+    // opposed to the camelCase DOM properties) is non-portable and
+    // non-standard but works in WebKit and IE (but not Gecko or Opera),
+    // we explicitly reject properties with dashes so that authors
+    // developing in WebKit or IE first don't end up with
+    // browser-specific content by accident.
+
+    function testProps( props, prefixed ) {
+        for ( var i in props ) {
+            var prop = props[i];
+            if ( !contains(prop, "-") && mStyle[prop] !== undefined ) {
+                return prefixed == 'pfx' ? prop : true;
+            }
+        }
+        return false;
+    }
+    /*>>testprop*/
+
+    // TODO :: add testDOMProps
+    /**
+     * testDOMProps is a generic DOM property test; if a browser supports
+     *   a certain property, it won't return undefined for it.
+     */
+    function testDOMProps( props, obj, elem ) {
+        for ( var i in props ) {
+            var item = obj[props[i]];
+            if ( item !== undefined) {
+
+                // return the property name as a string
+                if (elem === false) return props[i];
+
+                // let's bind a function
+                if (is(item, 'function')){
+                  // default to autobind unless override
+                  return item.bind(elem || obj);
+                }
+
+                // return the unbound function or obj or value
+                return item;
+            }
+        }
+        return false;
+    }
+
+    /*>>testallprops*/
+    /**
+     * testPropsAll tests a list of DOM properties we want to check against.
+     *   We specify literally ALL possible (known and/or likely) properties on
+     *   the element including the non-vendor prefixed one, for forward-
+     *   compatibility.
+     */
+    function testPropsAll( prop, prefixed, elem ) {
+
+        var ucProp  = prop.charAt(0).toUpperCase() + prop.slice(1),
+            props   = (prop + ' ' + cssomPrefixes.join(ucProp + ' ') + ucProp).split(' ');
+
+        // did they call .prefixed('boxSizing') or are we just testing a prop?
+        if(is(prefixed, "string") || is(prefixed, "undefined")) {
+          return testProps(props, prefixed);
+
+        // otherwise, they called .prefixed('requestAnimationFrame', window[, elem])
+        } else {
+          props = (prop + ' ' + (domPrefixes).join(ucProp + ' ') + ucProp).split(' ');
+          return testDOMProps(props, prefixed, elem);
+        }
+    }
+    /*>>testallprops*/
+
+
+    /**
+     * Tests
+     * -----
+     */
+
+    // The *new* flexbox
+    // dev.w3.org/csswg/css3-flexbox
+
+    tests['flexbox'] = function() {
+      return testPropsAll('flexWrap');
+    };
+
+    // The *old* flexbox
+    // www.w3.org/TR/2009/WD-css3-flexbox-20090723/
+
+    tests['flexboxlegacy'] = function() {
+        return testPropsAll('boxDirection');
+    };
+
+    // On the S60 and BB Storm, getContext exists, but always returns undefined
+    // so we actually have to call getContext() to verify
+    // github.com/Modernizr/Modernizr/issues/issue/97/
+
+    tests['canvas'] = function() {
+        var elem = document.createElement('canvas');
+        return !!(elem.getContext && elem.getContext('2d'));
+    };
+
+    tests['canvastext'] = function() {
+        return !!(Modernizr['canvas'] && is(document.createElement('canvas').getContext('2d').fillText, 'function'));
+    };
+
+    // webk.it/70117 is tracking a legit WebGL feature detect proposal
+
+    // We do a soft detect which may false positive in order to avoid
+    // an expensive context creation: bugzil.la/732441
+
+    tests['webgl'] = function() {
+        return !!window.WebGLRenderingContext;
+    };
+
+    /*
+     * The Modernizr.touch test only indicates if the browser supports
+     *    touch events, which does not necessarily reflect a touchscreen
+     *    device, as evidenced by tablets running Windows 7 or, alas,
+     *    the Palm Pre / WebOS (touch) phones.
+     *
+     * Additionally, Chrome (desktop) used to lie about its support on this,
+     *    but that has since been rectified: crbug.com/36415
+     *
+     * We also test for Firefox 4 Multitouch Support.
+     *
+     * For more info, see: modernizr.github.com/Modernizr/touch.html
+     */
+
+    tests['touch'] = function() {
+        var bool;
+
+        if(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
+          bool = true;
+        } else {
+          injectElementWithStyles(['@media (',prefixes.join('touch-enabled),('),mod,')','{#modernizr{top:9px;position:absolute}}'].join(''), function( node ) {
+            bool = node.offsetTop === 9;
+          });
+        }
+
+        return bool;
+    };
+
+
+    // geolocation is often considered a trivial feature detect...
+    // Turns out, it's quite tricky to get right:
+    //
+    // Using !!navigator.geolocation does two things we don't want. It:
+    //   1. Leaks memory in IE9: github.com/Modernizr/Modernizr/issues/513
+    //   2. Disables page caching in WebKit: webk.it/43956
+    //
+    // Meanwhile, in Firefox < 8, an about:config setting could expose
+    // a false positive that would throw an exception: bugzil.la/688158
+
+    tests['geolocation'] = function() {
+        return 'geolocation' in navigator;
+    };
+
+
+    tests['postmessage'] = function() {
+      return !!window.postMessage;
+    };
+
+
+    // Chrome incognito mode used to throw an exception when using openDatabase
+    // It doesn't anymore.
+    tests['websqldatabase'] = function() {
+      return !!window.openDatabase;
+    };
+
+    // Vendors had inconsistent prefixing with the experimental Indexed DB:
+    // - Webkit's implementation is accessible through webkitIndexedDB
+    // - Firefox shipped moz_indexedDB before FF4b9, but since then has been mozIndexedDB
+    // For speed, we don't test the legacy (and beta-only) indexedDB
+    tests['indexedDB'] = function() {
+      return !!testPropsAll("indexedDB", window);
+    };
+
+    // documentMode logic from YUI to filter out IE8 Compat Mode
+    //   which false positives.
+    tests['hashchange'] = function() {
+      return isEventSupported('hashchange', window) && (document.documentMode === undefined || document.documentMode > 7);
+    };
+
+    // Per 1.6:
+    // This used to be Modernizr.historymanagement but the longer
+    // name has been deprecated in favor of a shorter and property-matching one.
+    // The old API is still available in 1.6, but as of 2.0 will throw a warning,
+    // and in the first release thereafter disappear entirely.
+    tests['history'] = function() {
+      return !!(window.history && history.pushState);
+    };
+
+    tests['draganddrop'] = function() {
+        var div = document.createElement('div');
+        return ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div);
+    };
+
+    // FF3.6 was EOL'ed on 4/24/12, but the ESR version of FF10
+    // will be supported until FF19 (2/12/13), at which time, ESR becomes FF17.
+    // FF10 still uses prefixes, so check for it until then.
+    // for more ESR info, see: mozilla.org/en-US/firefox/organizations/faq/
+    tests['websockets'] = function() {
+        return 'WebSocket' in window || 'MozWebSocket' in window;
+    };
+
+
+    // css-tricks.com/rgba-browser-support/
+    tests['rgba'] = function() {
+        // Set an rgba() color and check the returned value
+
+        setCss('background-color:rgba(150,255,150,.5)');
+
+        return contains(mStyle.backgroundColor, 'rgba');
+    };
+
+    tests['hsla'] = function() {
+        // Same as rgba(), in fact, browsers re-map hsla() to rgba() internally,
+        //   except IE9 who retains it as hsla
+
+        setCss('background-color:hsla(120,40%,100%,.5)');
+
+        return contains(mStyle.backgroundColor, 'rgba') || contains(mStyle.backgroundColor, 'hsla');
+    };
+
+    tests['multiplebgs'] = function() {
+        // Setting multiple images AND a color on the background shorthand property
+        //  and then querying the style.background property value for the number of
+        //  occurrences of "url(" is a reliable method for detecting ACTUAL support for this!
+
+        setCss('background:url(https://),url(https://),red url(https://)');
+
+        // If the UA supports multiple backgrounds, there should be three occurrences
+        //   of the string "url(" in the return value for elemStyle.background
+
+        return (/(url\s*\(.*?){3}/).test(mStyle.background);
+    };
+
+
+
+    // this will false positive in Opera Mini
+    //   github.com/Modernizr/Modernizr/issues/396
+
+    tests['backgroundsize'] = function() {
+        return testPropsAll('backgroundSize');
+    };
+
+    tests['borderimage'] = function() {
+        return testPropsAll('borderImage');
+    };
+
+
+    // Super comprehensive table about all the unique implementations of
+    // border-radius: muddledramblings.com/table-of-css3-border-radius-compliance
+
+    tests['borderradius'] = function() {
+        return testPropsAll('borderRadius');
+    };
+
+    // WebOS unfortunately false positives on this test.
+    tests['boxshadow'] = function() {
+        return testPropsAll('boxShadow');
+    };
+
+    // FF3.0 will false positive on this test
+    tests['textshadow'] = function() {
+        return document.createElement('div').style.textShadow === '';
+    };
+
+
+    tests['opacity'] = function() {
+        // Browsers that actually have CSS Opacity implemented have done so
+        //  according to spec, which means their return values are within the
+        //  range of [0.0,1.0] - including the leading zero.
+
+        setCssAll('opacity:.55');
+
+        // The non-literal . in this regex is intentional:
+        //   German Chrome returns this value as 0,55
+        // github.com/Modernizr/Modernizr/issues/#issue/59/comment/516632
+        return (/^0.55$/).test(mStyle.opacity);
+    };
+
+
+    // Note, Android < 4 will pass this test, but can only animate
+    //   a single property at a time
+    //   daneden.me/2011/12/putting-up-with-androids-bullshit/
+    tests['cssanimations'] = function() {
+        return testPropsAll('animationName');
+    };
+
+
+    tests['csscolumns'] = function() {
+        return testPropsAll('columnCount');
+    };
+
+
+    tests['cssgradients'] = function() {
+        /**
+         * For CSS Gradients syntax, please see:
+         * webkit.org/blog/175/introducing-css-gradients/
+         * developer.mozilla.org/en/CSS/-moz-linear-gradient
+         * developer.mozilla.org/en/CSS/-moz-radial-gradient
+         * dev.w3.org/csswg/css3-images/#gradients-
+         */
+
+        var str1 = 'background-image:',
+            str2 = 'gradient(linear,left top,right bottom,from(#9f9),to(white));',
+            str3 = 'linear-gradient(left top,#9f9, white);';
+
+        setCss(
+             // legacy webkit syntax (FIXME: remove when syntax not in use anymore)
+              (str1 + '-webkit- '.split(' ').join(str2 + str1) +
+             // standard syntax             // trailing 'background-image:'
+              prefixes.join(str3 + str1)).slice(0, -str1.length)
+        );
+
+        return contains(mStyle.backgroundImage, 'gradient');
+    };
+
+
+    tests['cssreflections'] = function() {
+        return testPropsAll('boxReflect');
+    };
+
+
+    tests['csstransforms'] = function() {
+        return !!testPropsAll('transform');
+    };
+
+
+    tests['csstransforms3d'] = function() {
+
+        var ret = !!testPropsAll('perspective');
+
+        // Webkit's 3D transforms are passed off to the browser's own graphics renderer.
+        //   It works fine in Safari on Leopard and Snow Leopard, but not in Chrome in
+        //   some conditions. As a result, Webkit typically recognizes the syntax but
+        //   will sometimes throw a false positive, thus we must do a more thorough check:
+        if ( ret && 'webkitPerspective' in docElement.style ) {
+
+          // Webkit allows this media query to succeed only if the feature is enabled.
+          // `@media (transform-3d),(-webkit-transform-3d){ ... }`
+          injectElementWithStyles('@media (transform-3d),(-webkit-transform-3d){#modernizr{left:9px;position:absolute;height:3px;}}', function( node, rule ) {
+            ret = node.offsetLeft === 9 && node.offsetHeight === 3;
+          });
+        }
+        return ret;
+    };
+
+
+    tests['csstransitions'] = function() {
+        return testPropsAll('transition');
+    };
+
+
+    /*>>fontface*/
+    // @font-face detection routine by Diego Perini
+    // javascript.nwbox.com/CSSSupport/
+
+    // false positives:
+    //   WebOS github.com/Modernizr/Modernizr/issues/342
+    //   WP7   github.com/Modernizr/Modernizr/issues/538
+    tests['fontface'] = function() {
+        var bool;
+
+        injectElementWithStyles('@font-face {font-family:"font";src:url("https://")}', function( node, rule ) {
+          var style = document.getElementById('smodernizr'),
+              sheet = style.sheet || style.styleSheet,
+              cssText = sheet ? (sheet.cssRules && sheet.cssRules[0] ? sheet.cssRules[0].cssText : sheet.cssText || '') : '';
+
+          bool = /src/i.test(cssText) && cssText.indexOf(rule.split(' ')[0]) === 0;
+        });
+
+        return bool;
+    };
+    /*>>fontface*/
+
+    // CSS generated content detection
+    tests['generatedcontent'] = function() {
+        var bool;
+
+        injectElementWithStyles(['#',mod,'{font:0/0 a}#',mod,':after{content:"',smile,'";visibility:hidden;font:3px/1 a}'].join(''), function( node ) {
+          bool = node.offsetHeight >= 3;
+        });
+
+        return bool;
+    };
+
+
+
+    // These tests evaluate support of the video/audio elements, as well as
+    // testing what types of content they support.
+    //
+    // We're using the Boolean constructor here, so that we can extend the value
+    // e.g.  Modernizr.video     // true
+    //       Modernizr.video.ogg // 'probably'
+    //
+    // Codec values from : github.com/NielsLeenheer/html5test/blob/9106a8/index.html#L845
+    //                     thx to NielsLeenheer and zcorpan
+
+    // Note: in some older browsers, "no" was a return value instead of empty string.
+    //   It was live in FF3.5.0 and 3.5.1, but fixed in 3.5.2
+    //   It was also live in Safari 4.0.0 - 4.0.4, but fixed in 4.0.5
+
+    tests['video'] = function() {
+        var elem = document.createElement('video'),
+            bool = false;
+
+        // IE9 Running on Windows Server SKU can cause an exception to be thrown, bug #224
+        try {
+            if ( bool = !!elem.canPlayType ) {
+                bool      = new Boolean(bool);
+                bool.ogg  = elem.canPlayType('video/ogg; codecs="theora"')      .replace(/^no$/,'');
+
+                // Without QuickTime, this value will be `undefined`. github.com/Modernizr/Modernizr/issues/546
+                bool.h264 = elem.canPlayType('video/mp4; codecs="avc1.42E01E"') .replace(/^no$/,'');
+
+                bool.webm = elem.canPlayType('video/webm; codecs="vp8, vorbis"').replace(/^no$/,'');
+            }
+
+        } catch(e) { }
+
+        return bool;
+    };
+
+    tests['audio'] = function() {
+        var elem = document.createElement('audio'),
+            bool = false;
+
+        try {
+            if ( bool = !!elem.canPlayType ) {
+                bool      = new Boolean(bool);
+                bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/,'');
+                bool.mp3  = elem.canPlayType('audio/mpeg;')               .replace(/^no$/,'');
+
+                // Mimetypes accepted:
+                //   developer.mozilla.org/En/Media_formats_supported_by_the_audio_and_video_elements
+                //   bit.ly/iphoneoscodecs
+                bool.wav  = elem.canPlayType('audio/wav; codecs="1"')     .replace(/^no$/,'');
+                bool.m4a  = ( elem.canPlayType('audio/x-m4a;')            ||
+                              elem.canPlayType('audio/aac;'))             .replace(/^no$/,'');
+            }
+        } catch(e) { }
+
+        return bool;
+    };
+
+
+    // In FF4, if disabled, window.localStorage should === null.
+
+    // Normally, we could not test that directly and need to do a
+    //   `('localStorage' in window) && ` test first because otherwise Firefox will
+    //   throw bugzil.la/365772 if cookies are disabled
+
+    // Also in iOS5 Private Browsing mode, attempting to use localStorage.setItem
+    // will throw the exception:
+    //   QUOTA_EXCEEDED_ERRROR DOM Exception 22.
+    // Peculiarly, getItem and removeItem calls do not throw.
+
+    // Because we are forced to try/catch this, we'll go aggressive.
+
+    // Just FWIW: IE8 Compat mode supports these features completely:
+    //   www.quirksmode.org/dom/html5.html
+    // But IE8 doesn't support either with local files
+
+    tests['localstorage'] = function() {
+        try {
+            localStorage.setItem(mod, mod);
+            localStorage.removeItem(mod);
+            return true;
+        } catch(e) {
+            return false;
+        }
+    };
+
+    tests['sessionstorage'] = function() {
+        try {
+            sessionStorage.setItem(mod, mod);
+            sessionStorage.removeItem(mod);
+            return true;
+        } catch(e) {
+            return false;
+        }
+    };
+
+
+    tests['webworkers'] = function() {
+        return !!window.Worker;
+    };
+
+
+    tests['applicationcache'] = function() {
+        return !!window.applicationCache;
+    };
+
+
+    // Thanks to Erik Dahlstrom
+    tests['svg'] = function() {
+        return !!document.createElementNS && !!document.createElementNS(ns.svg, 'svg').createSVGRect;
+    };
+
+    // specifically for SVG inline in HTML, not within XHTML
+    // test page: paulirish.com/demo/inline-svg
+    tests['inlinesvg'] = function() {
+      var div = document.createElement('div');
+      div.innerHTML = '<svg/>';
+      return (div.firstChild && div.firstChild.namespaceURI) == ns.svg;
+    };
+
+    // SVG SMIL animation
+    tests['smil'] = function() {
+        return !!document.createElementNS && /SVGAnimate/.test(toString.call(document.createElementNS(ns.svg, 'animate')));
+    };
+
+    // This test is only for clip paths in SVG proper, not clip paths on HTML content
+    // demo: srufaculty.sru.edu/david.dailey/svg/newstuff/clipPath4.svg
+
+    // However read the comments to dig into applying SVG clippaths to HTML content here:
+    //   github.com/Modernizr/Modernizr/issues/213#issuecomment-1149491
+    tests['svgclippaths'] = function() {
+        return !!document.createElementNS && /SVGClipPath/.test(toString.call(document.createElementNS(ns.svg, 'clipPath')));
+    };
+
+    /*>>webforms*/
+    // input features and input types go directly onto the ret object, bypassing the tests loop.
+    // Hold this guy to execute in a moment.
+    function webforms() {
+        /*>>input*/
+        // Run through HTML5's new input attributes to see if the UA understands any.
+        // We're using f which is the <input> element created early on
+        // Mike Taylr has created a comprehensive resource for testing these attributes
+        //   when applied to all input types:
+        //   miketaylr.com/code/input-type-attr.html
+        // spec: www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#input-type-attr-summary
+
+        // Only input placeholder is tested while textarea's placeholder is not.
+        // Currently Safari 4 and Opera 11 have support only for the input placeholder
+        // Both tests are available in feature-detects/forms-placeholder.js
+        Modernizr['input'] = (function( props ) {
+            for ( var i = 0, len = props.length; i < len; i++ ) {
+                attrs[ props[i] ] = !!(props[i] in inputElem);
+            }
+            if (attrs.list){
+              // safari false positive's on datalist: webk.it/74252
+              // see also github.com/Modernizr/Modernizr/issues/146
+              attrs.list = !!(document.createElement('datalist') && window.HTMLDataListElement);
+            }
+            return attrs;
+        })('autocomplete autofocus list placeholder max min multiple pattern required step'.split(' '));
+        /*>>input*/
+
+        /*>>inputtypes*/
+        // Run through HTML5's new input types to see if the UA understands any.
+        //   This is put behind the tests runloop because it doesn't return a
+        //   true/false like all the other tests; instead, it returns an object
+        //   containing each input type with its corresponding true/false value
+
+        // Big thanks to @miketaylr for the html5 forms expertise. miketaylr.com/
+        Modernizr['inputtypes'] = (function(props) {
+
+            for ( var i = 0, bool, inputElemType, defaultView, len = props.length; i < len; i++ ) {
+
+                inputElem.setAttribute('type', inputElemType = props[i]);
+                bool = inputElem.type !== 'text';
+
+                // We first check to see if the type we give it sticks..
+                // If the type does, we feed it a textual value, which shouldn't be valid.
+                // If the value doesn't stick, we know there's input sanitization which infers a custom UI
+                if ( bool ) {
+
+                    inputElem.value         = smile;
+                    inputElem.style.cssText = 'position:absolute;visibility:hidden;';
+
+                    if ( /^range$/.test(inputElemType) && inputElem.style.WebkitAppearance !== undefined ) {
+
+                      docElement.appendChild(inputElem);
+                      defaultView = document.defaultView;
+
+                      // Safari 2-4 allows the smiley as a value, despite making a slider
+                      bool =  defaultView.getComputedStyle &&
+                              defaultView.getComputedStyle(inputElem, null).WebkitAppearance !== 'textfield' &&
+                              // Mobile android web browser has false positive, so must
+                              // check the height to see if the widget is actually there.
+                              (inputElem.offsetHeight !== 0);
+
+                      docElement.removeChild(inputElem);
+
+                    } else if ( /^(search|tel)$/.test(inputElemType) ){
+                      // Spec doesn't define any special parsing or detectable UI
+                      //   behaviors so we pass these through as true
+
+                      // Interestingly, opera fails the earlier test, so it doesn't
+                      //  even make it here.
+
+                    } else if ( /^(url|email)$/.test(inputElemType) ) {
+                      // Real url and email support comes with prebaked validation.
+                      bool = inputElem.checkValidity && inputElem.checkValidity() === false;
+
+                    } else {
+                      // If the upgraded input compontent rejects the :) text, we got a winner
+                      bool = inputElem.value != smile;
+                    }
+                }
+
+                inputs[ props[i] ] = !!bool;
+            }
+            return inputs;
+        })('search tel url email datetime date month week time datetime-local number range color'.split(' '));
+        /*>>inputtypes*/
+    }
+    /*>>webforms*/
+
+
+    // End of test definitions
+    // -----------------------
+
+
+
+    // Run through all tests and detect their support in the current UA.
+    // todo: hypothetically we could be doing an array of tests and use a basic loop here.
+    for ( var feature in tests ) {
+        if ( hasOwnProp(tests, feature) ) {
+            // run the test, throw the return value into the Modernizr,
+            //   then based on that boolean, define an appropriate className
+            //   and push it into an array of classes we'll join later.
+            featureName  = feature.toLowerCase();
+            Modernizr[featureName] = tests[feature]();
+
+            classes.push((Modernizr[featureName] ? '' : 'no-') + featureName);
+        }
+    }
+
+    /*>>webforms*/
+    // input tests need to run.
+    Modernizr.input || webforms();
+    /*>>webforms*/
+
+
+    /**
+     * addTest allows the user to define their own feature tests
+     * the result will be added onto the Modernizr object,
+     * as well as an appropriate className set on the html element
+     *
+     * @param feature - String naming the feature
+     * @param test - Function returning true if feature is supported, false if not
+     */
+     Modernizr.addTest = function ( feature, test ) {
+       if ( typeof feature == 'object' ) {
+         for ( var key in feature ) {
+           if ( hasOwnProp( feature, key ) ) {
+             Modernizr.addTest( key, feature[ key ] );
+           }
+         }
+       } else {
+
+         feature = feature.toLowerCase();
+
+         if ( Modernizr[feature] !== undefined ) {
+           // we're going to quit if you're trying to overwrite an existing test
+           // if we were to allow it, we'd do this:
+           //   var re = new RegExp("\\b(no-)?" + feature + "\\b");
+           //   docElement.className = docElement.className.replace( re, '' );
+           // but, no rly, stuff 'em.
+           return Modernizr;
+         }
+
+         test = typeof test == 'function' ? test() : test;
+
+         if (typeof enableClasses !== "undefined" && enableClasses) {
+           docElement.className += ' ' + (test ? '' : 'no-') + feature;
+         }
+         Modernizr[feature] = test;
+
+       }
+
+       return Modernizr; // allow chaining.
+     };
+
+
+    // Reset modElem.cssText to nothing to reduce memory footprint.
+    setCss('');
+    modElem = inputElem = null;
+
+    /*>>shiv*/
+    /**
+     * @preserve HTML5 Shiv prev3.7.1 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed
+     */
+    ;(function(window, document) {
+        /*jshint evil:true */
+        /** version */
+        var version = '3.7.0';
+
+        /** Preset options */
+        var options = window.html5 || {};
+
+        /** Used to skip problem elements */
+        var reSkip = /^<|^(?:button|map|select|textarea|object|iframe|option|optgroup)$/i;
+
+        /** Not all elements can be cloned in IE **/
+        var saveClones = /^(?:a|b|code|div|fieldset|h1|h2|h3|h4|h5|h6|i|label|li|ol|p|q|span|strong|style|table|tbody|td|th|tr|ul)$/i;
+
+        /** Detect whether the browser supports default html5 styles */
+        var supportsHtml5Styles;
+
+        /** Name of the expando, to work with multiple documents or to re-shiv one document */
+        var expando = '_html5shiv';
+
+        /** The id for the the documents expando */
+        var expanID = 0;
+
+        /** Cached data for each document */
+        var expandoData = {};
+
+        /** Detect whether the browser supports unknown elements */
+        var supportsUnknownElements;
+
+        (function() {
+          try {
+            var a = document.createElement('a');
+            a.innerHTML = '<xyz></xyz>';
+            //if the hidden property is implemented we can assume, that the browser supports basic HTML5 Styles
+            supportsHtml5Styles = ('hidden' in a);
+
+            supportsUnknownElements = a.childNodes.length == 1 || (function() {
+              // assign a false positive if unable to shiv
+              (document.createElement)('a');
+              var frag = document.createDocumentFragment();
+              return (
+                typeof frag.cloneNode == 'undefined' ||
+                typeof frag.createDocumentFragment == 'undefined' ||
+                typeof frag.createElement == 'undefined'
+              );
+            }());
+          } catch(e) {
+            // assign a false positive if detection fails => unable to shiv
+            supportsHtml5Styles = true;
+            supportsUnknownElements = true;
+          }
+
+        }());
+
+        /*--------------------------------------------------------------------------*/
+
+        /**
+         * Creates a style sheet with the given CSS text and adds it to the document.
+         * @private
+         * @param {Document} ownerDocument The document.
+         * @param {String} cssText The CSS text.
+         * @returns {StyleSheet} The style element.
+         */
+        function addStyleSheet(ownerDocument, cssText) {
+          var p = ownerDocument.createElement('p'),
+          parent = ownerDocument.getElementsByTagName('head')[0] || ownerDocument.documentElement;
+
+          p.innerHTML = 'x<style>' + cssText + '</style>';
+          return parent.insertBefore(p.lastChild, parent.firstChild);
+        }
+
+        /**
+         * Returns the value of `html5.elements` as an array.
+         * @private
+         * @returns {Array} An array of shived element node names.
+         */
+        function getElements() {
+          var elements = html5.elements;
+          return typeof elements == 'string' ? elements.split(' ') : elements;
+        }
+
+        /**
+         * Returns the data associated to the given document
+         * @private
+         * @param {Document} ownerDocument The document.
+         * @returns {Object} An object of data.
+         */
+        function getExpandoData(ownerDocument) {
+          var data = expandoData[ownerDocument[expando]];
+          if (!data) {
+            data = {};
+            expanID++;
+            ownerDocument[expando] = expanID;
+            expandoData[expanID] = data;
+          }
+          return data;
+        }
+
+        /**
+         * returns a shived element for the given nodeName and document
+         * @memberOf html5
+         * @param {String} nodeName name of the element
+         * @param {Document} ownerDocument The context document.
+         * @returns {Object} The shived element.
+         */
+        function createElement(nodeName, ownerDocument, data){
+          if (!ownerDocument) {
+            ownerDocument = document;
+          }
+          if(supportsUnknownElements){
+            return ownerDocument.createElement(nodeName);
+          }
+          if (!data) {
+            data = getExpandoData(ownerDocument);
+          }
+          var node;
+
+          if (data.cache[nodeName]) {
+            node = data.cache[nodeName].cloneNode();
+          } else if (saveClones.test(nodeName)) {
+            node = (data.cache[nodeName] = data.createElem(nodeName)).cloneNode();
+          } else {
+            node = data.createElem(nodeName);
+          }
+
+          // Avoid adding some elements to fragments in IE < 9 because
+          // * Attributes like `name` or `type` cannot be set/changed once an element
+          //   is inserted into a document/fragment
+          // * Link elements with `src` attributes that are inaccessible, as with
+          //   a 403 response, will cause the tab/window to crash
+          // * Script elements appended to fragments will execute when their `src`
+          //   or `text` property is set
+          return node.canHaveChildren && !reSkip.test(nodeName) && !node.tagUrn ? data.frag.appendChild(node) : node;
+        }
+
+        /**
+         * returns a shived DocumentFragment for the given document
+         * @memberOf html5
+         * @param {Document} ownerDocument The context document.
+         * @returns {Object} The shived DocumentFragment.
+         */
+        function createDocumentFragment(ownerDocument, data){
+          if (!ownerDocument) {
+            ownerDocument = document;
+          }
+          if(supportsUnknownElements){
+            return ownerDocument.createDocumentFragment();
+          }
+          data = data || getExpandoData(ownerDocument);
+          var clone = data.frag.cloneNode(),
+          i = 0,
+          elems = getElements(),
+          l = elems.length;
+          for(;i<l;i++){
+            clone.createElement(elems[i]);
+          }
+          return clone;
+        }
+
+        /**
+         * Shivs the `createElement` and `createDocumentFragment` methods of the document.
+         * @private
+         * @param {Document|DocumentFragment} ownerDocument The document.
+         * @param {Object} data of the document.
+         */
+        function shivMethods(ownerDocument, data) {
+          if (!data.cache) {
+            data.cache = {};
+            data.createElem = ownerDocument.createElement;
+            data.createFrag = ownerDocument.createDocumentFragment;
+            data.frag = data.createFrag();
+          }
+
+
+          ownerDocument.createElement = function(nodeName) {
+            //abort shiv
+            if (!html5.shivMethods) {
+              return data.createElem(nodeName);
+            }
+            return createElement(nodeName, ownerDocument, data);
+          };
+
+          ownerDocument.createDocumentFragment = Function('h,f', 'return function(){' +
+                                                          'var n=f.cloneNode(),c=n.createElement;' +
+                                                          'h.shivMethods&&(' +
+                                                          // unroll the `createElement` calls
+                                                          getElements().join().replace(/[\w\-]+/g, function(nodeName) {
+            data.createElem(nodeName);
+            data.frag.createElement(nodeName);
+            return 'c("' + nodeName + '")';
+          }) +
+            ');return n}'
+                                                         )(html5, data.frag);
+        }
+
+        /*--------------------------------------------------------------------------*/
+
+        /**
+         * Shivs the given document.
+         * @memberOf html5
+         * @param {Document} ownerDocument The document to shiv.
+         * @returns {Document} The shived document.
+         */
+        function shivDocument(ownerDocument) {
+          if (!ownerDocument) {
+            ownerDocument = document;
+          }
+          var data = getExpandoData(ownerDocument);
+
+          if (html5.shivCSS && !supportsHtml5Styles && !data.hasCSS) {
+            data.hasCSS = !!addStyleSheet(ownerDocument,
+                                          // corrects block display not defined in IE6/7/8/9
+                                          'article,aside,dialog,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}' +
+                                            // adds styling not present in IE6/7/8/9
+                                            'mark{background:#FF0;color:#000}' +
+                                            // hides non-rendered elements
+                                            'template{display:none}'
+                                         );
+          }
+          if (!supportsUnknownElements) {
+            shivMethods(ownerDocument, data);
+          }
+          return ownerDocument;
+        }
+
+        /*--------------------------------------------------------------------------*/
+
+        /**
+         * The `html5` object is exposed so that more elements can be shived and
+         * existing shiving can be detected on iframes.
+         * @type Object
+         * @example
+         *
+         * // options can be changed before the script is included
+         * html5 = { 'elements': 'mark section', 'shivCSS': false, 'shivMethods': false };
+         */
+        var html5 = {
+
+          /**
+           * An array or space separated string of node names of the elements to shiv.
+           * @memberOf html5
+           * @type Array|String
+           */
+          'elements': options.elements || 'abbr article aside audio bdi canvas data datalist details dialog figcaption figure footer header hgroup main mark meter nav output progress section summary template time video',
+
+          /**
+           * current version of html5shiv
+           */
+          'version': version,
+
+          /**
+           * A flag to indicate that the HTML5 style sheet should be inserted.
+           * @memberOf html5
+           * @type Boolean
+           */
+          'shivCSS': (options.shivCSS !== false),
+
+          /**
+           * Is equal to true if a browser supports creating unknown/HTML5 elements
+           * @memberOf html5
+           * @type boolean
+           */
+          'supportsUnknownElements': supportsUnknownElements,
+
+          /**
+           * A flag to indicate that the document's `createElement` and `createDocumentFragment`
+           * methods should be overwritten.
+           * @memberOf html5
+           * @type Boolean
+           */
+          'shivMethods': (options.shivMethods !== false),
+
+          /**
+           * A string to describe the type of `html5` object ("default" or "default print").
+           * @memberOf html5
+           * @type String
+           */
+          'type': 'default',
+
+          // shivs the document according to the specified `html5` object options
+          'shivDocument': shivDocument,
+
+          //creates a shived element
+          createElement: createElement,
+
+          //creates a shived documentFragment
+          createDocumentFragment: createDocumentFragment
+        };
+
+        /*--------------------------------------------------------------------------*/
+
+        // expose html5
+        window.html5 = html5;
+
+        // shiv the document
+        shivDocument(document);
+
+    }(this, document));
+    /*>>shiv*/
+
+    // Assign private properties to the return object with prefix
+    Modernizr._version      = version;
+
+    // expose these for the plugin API. Look in the source for how to join() them against your input
+    /*>>prefixes*/
+    Modernizr._prefixes     = prefixes;
+    /*>>prefixes*/
+    /*>>domprefixes*/
+    Modernizr._domPrefixes  = domPrefixes;
+    Modernizr._cssomPrefixes  = cssomPrefixes;
+    /*>>domprefixes*/
+
+    /*>>mq*/
+    // Modernizr.mq tests a given media query, live against the current state of the window
+    // A few important notes:
+    //   * If a browser does not support media queries at all (eg. oldIE) the mq() will always return false
+    //   * A max-width or orientation query will be evaluated against the current state, which may change later.
+    //   * You must specify values. Eg. If you are testing support for the min-width media query use:
+    //       Modernizr.mq('(min-width:0)')
+    // usage:
+    // Modernizr.mq('only screen and (max-width:768)')
+    Modernizr.mq            = testMediaQuery;
+    /*>>mq*/
+
+    /*>>hasevent*/
+    // Modernizr.hasEvent() detects support for a given event, with an optional element to test on
+    // Modernizr.hasEvent('gesturestart', elem)
+    Modernizr.hasEvent      = isEventSupported;
+    /*>>hasevent*/
+
+    /*>>testprop*/
+    // Modernizr.testProp() investigates whether a given style property is recognized
+    // Note that the property names must be provided in the camelCase variant.
+    // Modernizr.testProp('pointerEvents')
+    Modernizr.testProp      = function(prop){
+        return testProps([prop]);
+    };
+    /*>>testprop*/
+
+    /*>>testallprops*/
+    // Modernizr.testAllProps() investigates whether a given style property,
+    //   or any of its vendor-prefixed variants, is recognized
+    // Note that the property names must be provided in the camelCase variant.
+    // Modernizr.testAllProps('boxSizing')
+    Modernizr.testAllProps  = testPropsAll;
+    /*>>testallprops*/
+
+
+    /*>>teststyles*/
+    // Modernizr.testStyles() allows you to add custom styles to the document and test an element afterwards
+    // Modernizr.testStyles('#modernizr { position:absolute }', function(elem, rule){ ... })
+    Modernizr.testStyles    = injectElementWithStyles;
+    /*>>teststyles*/
+
+
+    /*>>prefixed*/
+    // Modernizr.prefixed() returns the prefixed or nonprefixed property name variant of your input
+    // Modernizr.prefixed('boxSizing') // 'MozBoxSizing'
+
+    // Properties must be passed as dom-style camelcase, rather than `box-sizing` hypentated style.
+    // Return values will also be the camelCase variant, if you need to translate that to hypenated style use:
+    //
+    //     str.replace(/([A-Z])/g, function(str,m1){ return '-' + m1.toLowerCase(); }).replace(/^ms-/,'-ms-');
+
+    // If you're trying to ascertain which transition end event to bind to, you might do something like...
+    //
+    //     var transEndEventNames = {
+    //       'WebkitTransition' : 'webkitTransitionEnd',
+    //       'MozTransition'    : 'transitionend',
+    //       'OTransition'      : 'oTransitionEnd',
+    //       'msTransition'     : 'MSTransitionEnd',
+    //       'transition'       : 'transitionend'
+    //     },
+    //     transEndEventName = transEndEventNames[ Modernizr.prefixed('transition') ];
+
+    Modernizr.prefixed      = function(prop, obj, elem){
+      if(!obj) {
+        return testPropsAll(prop, 'pfx');
+      } else {
+        // Testing DOM property e.g. Modernizr.prefixed('requestAnimationFrame', window) // 'mozRequestAnimationFrame'
+        return testPropsAll(prop, obj, elem);
+      }
+    };
+    /*>>prefixed*/
+
+
+    /*>>cssclasses*/
+    // Remove "no-js" class from <html> element, if it exists:
+    docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2') +
+
+                            // Add the new classes to the <html> element.
+                            (enableClasses ? ' js ' + classes.join(' ') : '');
+    /*>>cssclasses*/
+
+    return Modernizr;
+
+})(this, this.document);

--- a/app/assets/javascripts/timeline.js
+++ b/app/assets/javascripts/timeline.js
@@ -1,0 +1,26 @@
+jQuery(document).ready(function($){
+	var timelineBlocks = $('.cd-timeline-block'),
+		offset = 0.8;
+
+	//hide timeline blocks which are outside the viewport
+	hideBlocks(timelineBlocks, offset);
+
+	//on scolling, show/animate timeline blocks when enter the viewport
+	$(window).on('scroll', function(){
+		(!window.requestAnimationFrame) 
+			? setTimeout(function(){ showBlocks(timelineBlocks, offset); }, 100)
+			: window.requestAnimationFrame(function(){ showBlocks(timelineBlocks, offset); });
+	});
+
+	function hideBlocks(blocks, offset) {
+		blocks.each(function(){
+			( $(this).offset().top > $(window).scrollTop()+$(window).height()*offset ) && $(this).find('.cd-timeline-img, .cd-timeline-content').addClass('is-hidden');
+		});
+	}
+
+	function showBlocks(blocks, offset) {
+		blocks.each(function(){
+			( $(this).offset().top <= $(window).scrollTop()+$(window).height()*offset && $(this).find('.cd-timeline-img').hasClass('is-hidden') ) && $(this).find('.cd-timeline-img, .cd-timeline-content').removeClass('is-hidden').addClass('bounce-in');
+		});
+	}
+});

--- a/app/assets/partials/_layout.scss
+++ b/app/assets/partials/_layout.scss
@@ -1,0 +1,20 @@
+// breakpoints
+   
+$S:     320px;   
+$M:     768px;     
+$L:     1170px;     
+
+// media queries
+
+@mixin MQ($canvas) {
+  @if $canvas == S {
+   @media only screen and (min-width: $S) { @content; } 
+  }
+  @else if $canvas == M {
+   @media only screen and (min-width: $M) { @content; } 
+  }
+  @else if $canvas == L {
+   @media only screen and (min-width: $L) { @content; } 
+  }
+}
+

--- a/app/assets/partials/_mixins.scss
+++ b/app/assets/partials/_mixins.scss
@@ -1,0 +1,18 @@
+// rem fallback - credits: http://zerosixthree.se/
+
+@function calculateRem($size) {
+  $remSize: $size / 16px;
+  @return $remSize * 1rem;
+}
+
+@mixin font-size($size) {
+  font-size: $size;
+  font-size: calculateRem($size);
+}
+
+// border radius
+
+@mixin border-radius($radius:.25em) {
+  border-radius: $radius;
+}
+

--- a/app/assets/partials/_variables.scss
+++ b/app/assets/partials/_variables.scss
@@ -1,0 +1,16 @@
+// colors
+
+$main-text: #7f8c97; // main text
+$link: #acb7c0; // anchor tags
+$background: #e9f0f5; // body background color
+
+$color-1: #303e49; // blue dark
+$color-2: #c03b44; // red
+$color-3: #ffffff; // white
+$color-4: #75ce66; // green
+$color-5: #f0ca45; // yellow
+
+// fonts 
+
+$primary-font: 'Droid Serif', serif;
+$secondary-font: 'Open Sans', sans-serif;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -7,6 +7,7 @@
 @import "map";
 @import "deploy";
 @import "success_stories";
+@import "timeline";
 
 $navbar-height: 64px;
 
@@ -160,4 +161,8 @@ i.fa.medium {
 // darkens placeholder text
 ::-webkit-input-placeholder {
   color: $placeholder-text;
+}
+
+.text-center {
+  text-align: center;
 }

--- a/app/assets/stylesheets/timeline.css.scss
+++ b/app/assets/stylesheets/timeline.css.scss
@@ -1,0 +1,345 @@
+@import 'bourbon'; // http://bourbon.io/
+
+@import '../partials/variables'; // colors, fonts etc...
+
+@import '../partials/mixins'; // custom mixins
+
+@import '../partials/layout'; // responsive grid and media queries
+
+/* -------------------------------- 
+
+Modules - reusable parts of our design
+
+-------------------------------- */
+
+.cd-container { /* this class is used to give a max-width to the element it is applied to, and center it horizontally when it reaches that max-width */
+	width: 90%;
+	max-width: $L; // breakpoints inside partials > _layout.scss
+	margin: 0 auto;
+
+	&::after { /* clearfix */
+		content: '';
+		display: table;
+		clear: both;
+	}
+}
+
+/* -------------------------------- 
+
+Main components 
+
+-------------------------------- */
+
+header {
+	height: 200px;
+	line-height: 200px;
+	text-align: center;
+	background: $color-1;
+
+	h1 {
+		color: $color-3;
+		@include font-size(18px);
+	}
+
+	@include MQ(L) {
+		height: 300px;
+		line-height: 300px;
+
+		h1 {
+			@include font-size(24px);
+		}
+	}
+}
+
+#cd-timeline {
+	position: relative;
+	padding: 2em 0;
+	margin: {
+		top: 2em;
+		bottom: 2em;
+	}
+
+	&::before {
+		/* this is the vertical line */
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 18px;
+		height: 100%;
+		width: 4px;
+		background: darken($background, 5%);
+	}
+
+	@include MQ(L) {
+		margin: {
+			top: 3em;
+			bottom: 3em;
+		}
+
+		&::before {
+			left: 50%;
+			margin-left: -2px;
+		}
+	}
+}
+
+.cd-timeline-block {
+	position: relative;
+	margin: 2em 0;
+	@include clearfix;
+
+	&:first-child {
+		margin-top: 0;
+	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	@include MQ(L) {
+		margin: 4em 0;
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+}
+
+.cd-timeline-img {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	box-shadow: 0 0 0 4px $color-3, inset 0 2px 0 rgba(#000, .08), 0 3px 0 4px rgba(#000, .05) ;
+
+	img {
+		display: block;
+		width: 24px;
+		height: 24px;
+		position: relative;
+		left: 50%;
+		top: 50%;
+		margin-left: -12px;
+		margin-top: -12px;
+	}
+
+	&.cd-green {
+		background: $color-4;
+	}
+
+	&.cd-red {
+		background: $color-2;
+	}
+
+	&.cd-yellow {
+		background: $color-5;
+	}
+
+	@include MQ(L) {
+		width: 60px;
+		height: 60px;
+		left: 50%;
+		margin-left: -30px;
+
+		/* Force Hardware Acceleration in WebKit */
+		-webkit-transform: translateZ(0);
+		-webkit-backface-visibility: hidden;
+
+		.cssanimations &.is-hidden {
+			visibility: hidden;
+		}
+
+		.cssanimations &.bounce-in {
+			visibility: visible;
+			@include animation(cd-bounce-1 .6s);
+		}
+	}
+}
+
+@include keyframes(cd-bounce-1) {
+	0% {
+		opacity: 0;
+		@include transform(scale(.5));
+	}
+
+	60% {
+		opacity: 1;
+		@include transform(scale(1.2));
+	}
+
+	100% {
+		@include transform(scale(1));
+	}
+}
+
+.cd-timeline-content {
+	position: relative;
+	margin-left: 60px;
+	background: $color-3;
+	@include border-radius;
+	padding: 1em;
+	box-shadow: 0 3px 0 darken($background, 5%);
+	@include clearfix;
+
+	h2 {
+		color: $color-1;
+	}
+
+	p, .cd-read-more, .cd-date {
+		@include font-size(13px);
+	}
+
+	.cd-read-more, .cd-date {
+		display: inline-block;
+	}
+
+	p {
+		margin: 1em 0;
+		line-height: 1.6;
+	}
+
+	.cd-read-more {
+		float: right;
+		padding: .8em 1em;
+		background: $link;
+		color: $color-3;
+		@include border-radius;
+
+		.no-touch &:hover {
+			background-color: lighten($link, 5%);
+		}
+	}
+
+	.cd-date {
+		float: left;
+		padding: .8em 0;
+		opacity: .7;
+	}
+
+	&::before {
+		content: '';
+		position: absolute;
+		top: 16px;
+		right: 100%;
+		height: 0;
+		width: 0;
+		border: 7px solid transparent;
+		border-right: 7px solid $color-3;
+	}
+
+	@include MQ(M) {
+		h2 {
+			@include font-size(20px);
+		}
+
+		p {
+			@include font-size(16px);
+		}
+
+		.cd-read-more, .cd-date {
+			@include font-size(14px);
+		}
+	}
+
+	@include MQ(L) {
+		margin-left: 0;
+		padding: 1.6em;
+		width: 45%;
+
+		&::before {
+			top: 24px;
+			left: 100%;
+			border-color: transparent;
+			border-left-color: $color-3;
+		}
+
+		.cd-read-more {
+			float: left;
+		}
+
+		.cd-date {
+			position: absolute;
+			width: 100%;
+			left: 122%;
+			top: 6px;
+			@include font-size(16px);
+		}
+
+		.cd-timeline-block:nth-child(even) & {
+			float: right;
+
+			&::before {
+				top: 24px;
+				left: auto;
+				right: 100%;
+				border-color: transparent;
+				border-right-color: $color-3;
+			}
+
+			.cd-read-more {
+				float: right;
+			}
+
+			.cd-date {
+				left: auto;
+				right: 122%;
+				text-align: right;
+			}
+		}
+
+		.cssanimations &.is-hidden {
+			visibility: hidden;
+		}
+
+		.cssanimations &.bounce-in {
+			visibility: visible;
+			@include animation(cd-bounce-2 .6s);
+		}
+	}
+}
+
+@include MQ(L) {
+	/* inverse bounce effect on even content blocks */
+	.cssanimations .cd-timeline-block:nth-child(even) .cd-timeline-content.bounce-in {
+		@include animation(cd-bounce-2-inverse .6s);
+	}
+}
+
+@include keyframes(cd-bounce-2) {
+	0% {
+		opacity: 0;
+		@include transform(translateX(-100px));
+	}
+
+	60% {
+		opacity: 1;
+		@include transform(translateX(20px));
+	}
+
+	100% {
+		@include transform(translateX(0));
+	}
+}
+
+@include keyframes(cd-bounce-2-inverse) {
+	0% {
+		opacity: 0;
+		@include transform(translateX(100px));
+	}
+
+	60% {
+		opacity: 1;
+		@include transform(translateX(-20px));
+	}
+
+	100% {
+		@include transform(translateX(0));
+	}
+}
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
     google: ['Open Sans']
   }) %>
 
+  <script type="text/javascript" src="assets/modernizr.js"></script>
   <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
   <script type="text/javascript"> Stripe.setPublishableKey('pk_live_bqebTTza5PGXJcAAaivllE03');</script>
     <!-- Start of Async Drift Code -->

--- a/app/views/pages/history.html.erb
+++ b/app/views/pages/history.html.erb
@@ -1,205 +1,510 @@
-  <div class="container">
-    <div class="row">
-      <div class="col m12">
-        <h3>Our History</h3>
+  <h3 class="text-center">Our History</h3>
+  <section id="cd-timeline" class="cd-container">
+		<div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
 
-        <h4>2012: It all starts with a hackathon</h4>
-        <li>
+			<div class="cd-timeline-content">
+				<h2>It all starts with a hackathon</h2>
+				<p>
             Our founder and retired U.S. Army Captain David Molina attends his first hackathon in New York City.
             After a weekend learning at <a href="http://angelhack.com" target="_blank">AngelHack</a> he is inspired to pursue software
             craftsmanship as a post-military occupation. He submits his application to The Flatiron School while on
             active-duty only to discover that the program does not accept the New GI Bill as payment.
-        </li>
-        <li>
-          Molina exits military serve in early 2013 and begins to self-learn Ruby on Rails, a full-stack web
-          development platform for building comprehensive web applications attending
-          <a href="http://bmoreonrails.org" target="_blank">Bmore on Rails</a> meetups and taking
-          <a href="http://onemonth.com" target="_blank">One Month Rails</a> online.
-        </li>
+				</p>
+				<span class="cd-date">2012</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <h4>2013: The vision becomes clearer</h4>
-        <li>
-          Molina attends <a href="http://railsconf.com" target="_blank">RailsConf</a> as a scholarship fellow and is introduced to
-          the Portland ruby group and rubyists from around the world.
-        </li>
-        <li>
-          Molina is selected and attends <a href="http://techstars.com/patriotbootcamp" target="_blank">Techstars Patriot Boot Camp (PBC)</a>
-          at George Washington University. There he raises the problem to guest speaker and Virginia Senator Tim Kaine of the
-          inability of using the New GI Bill to go to code school and prepare for the modern workforce. Before departing D.C.,
-          Molina takes an Uber to the U.S. Capitol and meets with U.S. Army Congressional Fellow Ben Culver. Culver recommends
-          gathering the following data:
-          <ol>
-            <li>Number of veterans who are interested in coding as a post-military occupation.</li>
-            <li>Assessing the interest among all code schools nationally.</li>
-            <li>Determining the overall associated costs with implementing a broad reaching program.</li>
-          </ol>
-        </li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
 
-        <li>
-          Molina purchases opcod3.us and begins working on a first draft of this website with fellow Army veteran and software
-          developer Don Livanec.
-        </li>
+			<div class="cd-timeline-content">
+				<h2>One Month Rails</h2>
+				<p>
+            Molina exits military serve in early 2013 and begins to self-learn Ruby on Rails, a full-stack web
+            development platform for building comprehensive web applications attending
+            <a href="http://bmoreonrails.org" target="_blank">Bmore on Rails</a> meetups and taking
+            <a href="http://onemonth.com" target="_blank">One Month Rails</a> online.
+        </p>
+				<span class="cd-date">2013</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <h4>2014: Operation Code is a go</h4>
-        <li>
-          At <a href="http://cascadiarubyconf.com" target="_blank">Cascadia Ruby</a>, Molina is encouraged by fellow rubyist, Whitney Rose,
-          to launch Operation Code's petition using Launchrock, and seperate the main application using Ruby on Rails for first iteration.
-          After lengthy discussions with Kristin Smith (<a href="https://www.codefellows.org">Code Fellows</a>) and Adam Enbar (The Flatiron School), the first line of code is
-          committed to GitHub on <a href="https://github.com/OperationCode/operationcode" target="_blank">August 21st, 2014</a>.
-        </li>
+		<div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
 
-        <blockquote class="twitter-tweet" data-lang="en">
-          <p lang="en" dir="ltr">
-            <a href="http://t.co/EdlBHLYVmM" target="_blank">http://t.co/EdlBHLYVmM</a> is live. If you&#39;re a <a href="https://twitter.com/hashtag/Veteran?src=hash" target="_blank">#Veteran</a>
-            and want to learn to <a href="https://twitter.com/hashtag/code?src=hash" target="_blank">#code</a>, join us.
-            <a href="http://t.co/gQv86By38i" target="_blank">pic.twitter.com/gQv86By38i</a></p>&mdash; Operation Code (@operation_code)
-            <a href="https://twitter.com/operation_code/status/500155388889931776" target="_blank">August 15, 2014</a>
-        </blockquote>
+			<div class="cd-timeline-content">
+				<h2>The vision becomes clearer</h2>
+				<p>
+            Molina attends <a href="http://railsconf.com" target="_blank">RailsConf</a> as a scholarship fellow and is introduced to
+            the Portland ruby group and rubyists from around the world.
+        </p>
+				<span class="cd-date">2013</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <li>
-          Louisiana native, Army veteran and software developer Dr. James Davis joins Operation Code and supplies substantial incremental software functionality
-          integrating the petition into the rails application.
-        </li>
+		<div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
 
-        <li>
-          Molina begins pairing software developers and veterans to get coding faster. The 1-on-1 Software Mentor Protégé Program kicks off with HTML/CSS,
-          JavaScript and Ruby on Rails. Dr. Davis becomes the first mentor and over a dozen veterans sign up to learn to code.
-        </li>
+			<div class="cd-timeline-content">
+				<h2>Patriot Boot Camp</h2>
+				<p>
+            Molina is selected and attends <a href="http://techstars.com/patriotbootcamp" target="_blank">Techstars Patriot Boot Camp (PBC)</a>
+            at George Washington University. There he raises the problem to guest speaker and Virginia Senator Tim Kaine of the
+            inability of using the New GI Bill to go to code school and prepare for the modern workforce. Before departing D.C.,
+            Molina takes an Uber to the U.S. Capitol and meets with U.S. Army Congressional Fellow Ben Culver. Culver recommends
+            gathering the following data:
+            <ol>
+              <li>Number of veterans who are interested in coding as a post-military occupation.</li>
+              <li>Assessing the interest among all code schools nationally.</li>
+              <li>Determining the overall associated costs with implementing a broad reaching program.</li>
+            </ol>
+        </p>
+				<span class="cd-date">2013</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <li>
-          Web developer, teacher, entrepreneur and co-founder of <a href="https://www.codefellows.org">Code Fellows</a>, Ivan Storck, purchases <a href="http://operationcode.org">operationcode.org</a>
-          for Operation Code. Becomes our first in-kind donor.
-        </li>
+		<div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
 
-        <li>
-          <a href="http://dnsimple.com" target="_blank">DNSimple</a> joins Operation Code as our domain management service provider ensuring this site is operational 24/7.
-        </li>
+			<div class="cd-timeline-content">
+				<h2>First draft</h2>
+				<p>
+            Molina purchases opcod3.us and begins working on a first draft of this website with fellow Army veteran and software
+            developer Don Livanec.
+        </p>
+				<span class="cd-date">2013</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <li>
-          Army veteran and aspiring software developer, Charles Sipe, contributes guest post,
-          "<a href="https://www.switchup.org/blog/why-veterans-will-make-excellent-programmers" target="_blank">Why veterans will make excellent programs</a>,"
-          at switchup.org published on Veteran's Day and goes viral.
-        </li>
+		<div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
 
-        <li>
-          New York City-based, HackHands co-founders, Forest Good &amp; Geraldo Ramos, join Operation Code. Good &amp; Ramos design our logo and provide
-          our veterans access to <a href="https://hacksummit.org" target="_blank">hack.summit()</a>, a virtual conference to learn from the world's most renowned programmers.
-        </li>
+			<div class="cd-timeline-content">
+				<h2>Operation Code is a go</h2>
+				<p>
+            At <a href="http://cascadiarubyconf.com" target="_blank">Cascadia Ruby</a>, Molina is encouraged by fellow rubyist, Whitney Rose,
+            to launch Operation Code's petition using Launchrock, and seperate the main application using Ruby on Rails for first iteration.
+            After lengthy discussions with Kristin Smith (<a href="https://www.codefellows.org">Code Fellows</a>) and Adam Enbar (The Flatiron School), the first line of code is
+            committed to GitHub on <a href="https://github.com/OperationCode/operationcode" target="_blank">August 21st, 2014</a>.
 
-        <blockquote class="twitter-tweet" data-lang="en">
-          <p lang="en" dir="ltr">
-            Thanks <a href="https://twitter.com/hackhands" target="_blank">@hackhands</a> co-founders, <a href="https://twitter.com/ForestGood" target="_blank">@forestgood</a>
-            &amp; <a href="https://twitter.com/geraldoramos" target="_blank">@geraldoramos</a>, for hacking a logo for us! We&#39;re stoked.
-            <a href="https://twitter.com/hashtag/officialnow?src=hash" target="_blank">#officialnow</a>
-            <a href="http://t.co/Y5RvzVGF5Q" target="_blank">pic.twitter.com/Y5RvzVGF5Q</a>
-          </p>
-          &mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/557339630958174208" target="_blank">January 20, 2015</a>
-        </blockquote>
+            <blockquote class="twitter-tweet" data-lang="en">
+              <p lang="en" dir="ltr">
+                <a href="http://t.co/EdlBHLYVmM" target="_blank">http://t.co/EdlBHLYVmM</a> is live. If you&#39;re a <a href="https://twitter.com/hashtag/Veteran?src=hash" target="_blank">#Veteran</a>
+                and want to learn to <a href="https://twitter.com/hashtag/code?src=hash" target="_blank">#code</a>, join us.
+                <a href="http://t.co/gQv86By38i" target="_blank">pic.twitter.com/gQv86By38i</a></p>&mdash; Operation Code (@operation_code)
+                <a href="https://twitter.com/operation_code/status/500155388889931776" target="_blank">August 15, 2014</a>
+            </blockquote>  
+        </p>
+				<span class="cd-date">August 15, 2014</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <h4>2015: Scaling to new heights</h4>
-        <li>
-          Software developer Chris Hough joins Operation Code and provides software architecture advice that improves application functionality and speed.
-          The open source code is moved from Molina's personal repo to an <a href="http://github.com/operationcode/operationcode" target="_blank">organizational repo</a>
-          and half a dozen contributors join the team.
-        </li>
-        <li>
-          Former President/CEO of United Way of Columbia-Willamette Jay Bloom and former Assistant Secretary of Veterans Affairs John Garcia join the
-          Operation Code advisory team.
-        </li>
-        <li>
-          Bend, Oregon-based, <a href="http://ruby.onales.com" target="_blank">Ruby on Ales</a> becomes first software developer industry conference to support veterans
-          with ruby programming education. Four scholarships are awarded to two Army vets, one Marine vet, and one Navy vet.
-        </li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
 
-        <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Meet <a href="https://twitter.com/USNavy" target="_blank">@USNavy</a> <a href="https://twitter.com/hashtag/Veteran?src=hash" target="_blank">#Veteran</a> <a href="https://twitter.com/RandyLeighton" target="_blank">@RandyLeighton</a>. Previously, unemployed.
-        <a href="https://twitter.com/epicodus" target="_blank">@epicodus</a> grad and <br>now coder <a href="https://twitter.com/hashtag/inBend?src=hash" target="_blank">#inBend</a>. <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="http://t.co/LjdR8m3i9q" target="_blank">pic.twitter.com/LjdR8m3i9q</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/573615090202705920" target="_blank">March 5, 2015</a></blockquote>
-        <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+			<div class="cd-timeline-content">
+				<h2>Dr. Davis joins the team</h2>
+				<p>
+            Louisiana native, Army veteran and software developer Dr. James Davis joins Operation Code and supplies substantial incremental software functionality
+            integrating the petition into the rails application.
+        </p>
+				<span class="cd-date">2014</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <li>Following the two-day, McMenamins hosts us afterwards to do a tech workshop for the local veterans community.</p></li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
 
-        <a href="https://twitter.com/RandyLeighton" target="_blank">@RandyLeighton</a>, Tom,
-        <a href="https://twitter.com/dataface" target="_blank">@dataface</a> and <a href="https://twitter.com/davidcmolina" target="_blank">@davidcmolina</a> after tech workshop. Thanks McMenamins for hosting! <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="http://t.co/bmEr62TOaa" target="_blank">pic.twitter.com/bmEr62TOaa</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/574337457992437760" target="_blank">March 7, 2015</a></blockquote>
+			<div class="cd-timeline-content">
+				<h2>Pairing begins</h2>
+				<p>
+            Molina begins pairing software developers and veterans to get coding faster. The 1-on-1 Software Mentor Protégé Program kicks off with HTML/CSS,
+            JavaScript and Ruby on Rails. Dr. Davis becomes the first mentor and over a dozen veterans sign up to learn to code.
+        </p>
+				<span class="cd-date">2014</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <li>Columbia Journalism School grad and former Mint reporter Teresa Mahoney joins Operation Code to <a href="/media">interview veterans</a> from across the country, and craft our story using video to drive more public awareness.</p></li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
 
-      <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/hashtag/tbt?src=hash" target="_blank">#tbt</a> when we were at <a href="https://twitter.com/epicodus" target="_blank">@epicodus</a> w/ <a href="https://twitter.com/bRonFloyd" target="_blank">@bRonFloyd</a> and <a href="https://twitter.com/TeresaMahoney" target="_blank">@TeresaMahoney</a>. <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="https://twitter.com/hashtag/pdx?src=hash" target="_blank">#pdx</a>
-        <a href="http://t.co/EVM2UlvfRj" target="_blank">pic.twitter.com/EVM2UlvfRj</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/578757286312673280" target="_blank">March 20, 2015</a></blockquote>
+			<div class="cd-timeline-content">
+				<h2>First donor</h2>
+				<p>
+            Web developer, teacher, entrepreneur and co-founder of <a href="https://www.codefellows.org">Code Fellows</a>, Ivan Storck, purchases <a href="http://operationcode.org">operationcode.org</a>
+            for Operation Code. Becomes our first in-kind donor.
+        </p>
+				<span class="cd-date">2014</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <li>Operation Code changes it's Twitter handle to <a href="http://twitter.com/operation_code" target="_blank">@operation_code</a> for more effective branding, as well as <a href="http://instagram.com/operation_code" target="_blank">Instagram</a> and <a href="http://facebook.com/operationcode.org" target="_blank">Facebook</a>.</p></li>
-      <li>Formal launch of Operation Code. The <a href="http://calagator.org/events/1250468219" target="_blank">April 16th launch party</a> brings veteran coders, software developers, media and officials from U.S. Senator Ron Wyden and Congressman Blumenauer's office.
-<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Friends of <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> for our Launch Party at <a href="https://twitter.com/epicodus" target="_blank">@epicodus</a> <a href="https://twitter.com/hashtag/tbt?src=hash" target="_blank">#tbt</a> <a href="http://t.co/mn6mKx7D23" target="_blank">pic.twitter.com/mn6mKx7D23</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/591485986875420673" target="_blank">April 24, 2015</a></blockquote>
-      </p></li>
-      <li>Army veteran and software developer Fernando Paredes joins Operation Code and expands the Software Mentor Protégé Program to Peer-to-Peer mentorship using <a href="https://operation-code.slack.com/" target="_blank">Slack</a>. Paredes creates the following channels: Android, Ember, Go, HTML/CSS, iOS, Java, JavaScript, PHP, Python, and Ruby. Veterans now have instant access to a veterans coding community and software mentors accessible in the browser, desktop and via native app.</p></li>
-      <li>Software developers, Fernando Paredes, Nell Shamrell, and Eric McKenna help make Operation Code more open and developer user-friendly by creating a <a href="https://github.com/OperationCode/operationcode/blob/master/CONTRIBUTING.md" target="_blank">contributing guide</a>.</p></li>
-      <li>Global hospitality provider, <a href="https://www.airbnb.com/" target="_blank">Airbnb</a> sponsors Operation Code veterans lodging requirements while visiting San Francisco for Signal. HQ tour is <a href="https://www.instagram.com/p/21p5bFxUjd/?taken-by=davidcmolina" target="_blank">provided</a> and Airbnb becomes official lodging sponsor for veterans doing job interviews going forward.</p></li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
 
-      <li>San Francisco-based, <a href="https://www.twilio.com/signal/2015" target="_blank">SignalConf</a> becomes 2nd software developer industry conference to support Operation Code veterans to keep coding and building software. Three scholarships are awarded to two Army vets, and one Navy vet. Operation Code veterans tour Twilio.</p></li>
-      <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Special shout out to <a href="https://twitter.com/twilio" target="_blank">@twilio</a> <a href="https://twitter.com/Airbnb" target="_blank">@Airbnb</a> for making it possible for our <a href="https://twitter.com/hashtag/veterans?src=hash" target="_blank">#veterans</a> to attend <a href="https://twitter.com/signalconf" target="_blank">@signalconf</a> this week. <a href="http://t.co/EWomd8fwq4" target="_blank">pic.twitter.com/EWomd8fwq4</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/600721740948312066" target="_blank">May 19, 2015</a></blockquote>
+			<div class="cd-timeline-content">
+				<h2>DNSimple joins</h2>
+				<p>
+            <a href="http://dnsimple.com" target="_blank">DNSimple</a> joins Operation Code as our domain management service provider ensuring this site is operational 24/7.
+        </p>
+				<span class="cd-date">2014</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Our team on the ground at <a href="https://twitter.com/twilio" target="_blank">@twilio</a> HQ w/ @TheINDIEHost. <a href="https://twitter.com/hashtag/SignalConf?src=hash" target="_blank">#SignalConf</a>
-        <a href="https://twitter.com/signalconf" target="_blank">@signalconf</a> <a href="http://t.co/3xq2f0VaSa" target="_blank">pic.twitter.com/3xq2f0VaSa</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/601187508160978944" target="_blank">May 21, 2015</a></blockquote>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
 
-        <li>While in San Francisco, Operation Code Founder David Molina hosts a meetup at 21st Amendment that is attended by Elmer Thomas (SendGrid), Laura Gómez (Atipica), Nick Frost (Navy Veteran) and Pete Runyon (Marine Veteran). The following day Pete accompanies David on meetings throughout San Francisco.</p></li>
+			<div class="cd-timeline-content">
+				<h2>Sipe contributions</h2>
+				<p>
+            Army veteran and aspiring software developer, Charles Sipe, contributes guest post,
+            "<a href="https://www.switchup.org/blog/why-veterans-will-make-excellent-programmers" target="_blank">Why veterans will make excellent programs</a>,"
+            at switchup.org published on Veteran's Day and goes viral.
+        </p>
+				<span class="cd-date">2014</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-        <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Thank you <a href="https://twitter.com/21stAmendment" target="_blank">@21stAmendment</a> for last night, the amazing hospitality and excellent beer selection! <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> #👊 <a href="http://t.co/ySLX29i7Xt" target="_blank">pic.twitter.com/ySLX29i7Xt</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/601403833395347456" target="_blank">May 21, 2015</a></blockquote>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
 
-      <li>To meet growth demands, Operation Code <a href="https://twitter.com/operation_code/status/614443994769027072" target="_blank">separates</a> from its fiscal sponsor/agent, The Cogostar Foundation, recruits new <a href="https://operationcode.org/blog/2015/09/30/announcing-operation-code-board-officers.html" target="_blank">founding governing board of directors</a> comprised of Army, Marine, and Navy veterans, an Army spouse, software developers and technology entrepreneurs, to include: Josh Carter, Aimee Knight, Nick Frost, Pete Runyon, Laura Gómez, Fernando Paredes, and Elmer Thomas. Operation Code incorporates as an Oregon nonprofit.</p></li>
+			<div class="cd-timeline-content">
+				<h2>Good and Ramos join the team</h2>
+				<p>
+            New York City-based, HackHands co-founders, Forest Good &amp; Geraldo Ramos, join Operation Code. Good &amp; Ramos design our logo and provide
+            our veterans access to <a href="https://hacksummit.org" target="_blank">hack.summit()</a>, a virtual conference to learn from the world's most renowned programmers.
+            <blockquote class="twitter-tweet" data-lang="en">
+              <p lang="en" dir="ltr">
+                Thanks <a href="https://twitter.com/hackhands" target="_blank">@hackhands</a> co-founders, <a href="https://twitter.com/ForestGood" target="_blank">@forestgood</a>
+                &amp; <a href="https://twitter.com/geraldoramos" target="_blank">@geraldoramos</a>, for hacking a logo for us! We&#39;re stoked.
+                <a href="https://twitter.com/hashtag/officialnow?src=hash" target="_blank">#officialnow</a>
+                <a href="http://t.co/Y5RvzVGF5Q" target="_blank">pic.twitter.com/Y5RvzVGF5Q</a>
+              </p>
+              &mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/557339630958174208" target="_blank">January 20, 2015</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">January 19, 2014</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <li>Powered by Stripe, Operation Code incorporates SSL for the domain and begins accepting online donations.</p></li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
 
-        <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Your request to have an in-house donation capable form has been heard. Thanks to <a href="https://twitter.com/stripe" target="_blank">@stripe</a> we&#39;re here! <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="http://t.co/B1NO0udWXd" target="_blank">pic.twitter.com/B1NO0udWXd</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/619872618317901825" target="_blank">July 11, 2015</a></blockquote>
+			<div class="cd-timeline-content">
+				<h2>Scaling to new heights</h2>
+				<p>
+            Software developer Chris Hough joins Operation Code and provides software architecture advice that improves application functionality and speed.
+            The open source code is moved from Molina's personal repo to an <a href="http://github.com/operationcode/operationcode" target="_blank">organizational repo</a>
+            and half a dozen contributors join the team.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <li><a href="https://www.stickermule.com/" target="_blank">Sticker Mule</a> sponsors stickers and we begin covering laptops everywhere.</p></li>
-      <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Our <a href="https://twitter.com/stickermule" target="_blank">@stickermule</a>&#39;s fresh off the Oregon Trail. h/t <a href="https://twitter.com/hackhands" target="_blank">@hackhands</a> <a href="https://twitter.com/adorableio" target="_blank">@adorableio</a> <a href="https://twitter.com/hashtag/operationcode?src=hash">#operationcode</a> <a href="http://t.co/5BOhQXwkL7" target="_blank">pic.twitter.com/5BOhQXwkL7</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/607978609785962497" target="_blank">June 8, 2015</a></blockquote>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
 
-      <li>
-        Founder of one of the first and largest high school hackathons, hackBCA, Jared Zoneraich joins the Operation Code advisory team.
-      </li>
+			<div class="cd-timeline-content">
+				<h2>Jay Bloom joins advisory team</h2>
+				<p>
+            Former President/CEO of United Way of Columbia-Willamette Jay Bloom and former Assistant Secretary of Veterans Affairs John Garcia join the
+            Operation Code advisory team.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <li>
-        Attorney, entrepreneur and ex-Army Captain, Mark Kerr <a href="https://operationcode.org/blog/2015/11/08/introducing-the-new-operation-code-board-chair.html">
-        joins</a> the Operation Code board of directors. He is elected chair of the board, and the board begins having regular conference calls
-        focusing on infrastructure, processes &amp; procedures, and fundraising strategy.
-      </li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
 
-      <h4>2016: Filing and growth</h4>
-      <li>
-        <a href="https://hacksummit.org/" target="_blank">hack.summit()</a> adds Operation Code to its list of coding nonprofits, and more military veterans attend.
-      </li>
+			<div class="cd-timeline-content">
+				<h2>Ruby on Ales</h2>
+				<p>
+            Bend, Oregon-based, <a href="http://ruby.onales.com" target="_blank">Ruby on Ales</a> becomes first software developer industry conference to support veterans
+            with ruby programming education. Four scholarships are awarded to two Army vets, one Marine vet, and one Navy vet.
+            <blockquote class="twitter-tweet" data-lang="en">
+              <p lang="en" dir="ltr">Meet <a href="https://twitter.com/USNavy" target="_blank">@USNavy</a> <a href="https://twitter.com/hashtag/Veteran?src=hash" target="_blank">#Veteran</a> <a href="https://twitter.com/RandyLeighton" target="_blank">@RandyLeighton</a>. Previously, unemployed.
+              <a href="https://twitter.com/epicodus" target="_blank">@epicodus</a> grad and <br>now coder <a href="https://twitter.com/hashtag/inBend?src=hash" target="_blank">#inBend</a>. <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="http://t.co/LjdR8m3i9q" target="_blank">pic.twitter.com/LjdR8m3i9q</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/573615090202705920" target="_blank">March 5, 2015</a></blockquote>
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+        </p>
+				<span class="cd-date">March 5, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <blockquote class="twitter-tweet" data-lang="en">
-        <p lang="en" dir="ltr">Wondering what happened to hack.summit() and when? Mark it on your calendars: Feb 22-25th -
-        <a href="https://t.co/pfExk2VeTB" target="_blank">https://t.co/pfExk2VeTB</a> <a href="https://t.co/QoQj9QlRIG" target="_blank">pic.twitter.com/QoQj9QlRIG</a></p>
-        &mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/692580768313384960" target="_blank">January 28, 2016</a>
-      </blockquote>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
 
-      <li>
-        <a href="http://speakeasy.co/" target="_blank">Speakeasy</a> joins as the Operation Code conference sponsor. The Operation Code Battle Rhythym pencils in the
-        first Tuesday of the month for its governing Board of Director calls.
-      </li>
+			<div class="cd-timeline-content">
+				<h2>McMenamin hosts</h2>
+				<p>
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              <a href="https://twitter.com/RandyLeighton" target="_blank">@RandyLeighton</a>, Tom,
+              <a href="https://twitter.com/dataface" target="_blank">@dataface</a> and <a href="https://twitter.com/davidcmolina" target="_blank">@davidcmolina</a> after tech workshop. Thanks McMenamins for hosting! <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="http://t.co/bmEr62TOaa" target="_blank">pic.twitter.com/bmEr62TOaa</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/574337457992437760" target="_blank">March 7, 2015</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">March 7, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <li>
-        Operation Code prepares 501(c)(3) application. Marine Veteran and Board Secretary/Treasurer Pete Runyon drops
-        $850 for the fee and its shipped.</p>
-      </li>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
 
-      <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Things are moving.
-        <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="https://t.co/usY95axRmr" target="_blank">pic.twitter.com/usY95axRmr</a>
-        </p>&mdash; Operation Code (@operation_code)
-        <a href="https://twitter.com/operation_code/status/707267330066108417" target="_blank">March 8, 2016</a>
-      </blockquote>
+			<div class="cd-timeline-content">
+				<h2>Teresa Mahoney joins the team</h2>
+				<p>
+            Columbia Journalism School grad and former Mint reporter Teresa Mahoney joins Operation Code to <a href="/media">interview veterans</a> from across the country, and craft our story using video to drive more public awareness.
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/hashtag/tbt?src=hash" target="_blank">#tbt</a> when we were at <a href="https://twitter.com/epicodus" target="_blank">@epicodus</a> w/ <a href="https://twitter.com/bRonFloyd" target="_blank">@bRonFloyd</a> and <a href="https://twitter.com/TeresaMahoney" target="_blank">@TeresaMahoney</a>. <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="https://twitter.com/hashtag/pdx?src=hash" target="_blank">#pdx</a>
+              <a href="http://t.co/EVM2UlvfRj" target="_blank">pic.twitter.com/EVM2UlvfRj</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/578757286312673280" target="_blank">March 20, 2015</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">March 19, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
 
-      <li>
-        ~41 business days later, Operation Code is a 501(c)(3) nonprofit organization.
-      </li>
-      <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
-        ... And, ~41 business days later we&#39;re tax-exempt. Now back to work. Together we are
-        <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a>.
-        <a href="https://t.co/SZYij4Qs2R" target="_blank">pic.twitter.com/SZYij4Qs2R</a></p>&mdash; Operation Code (@operation_code)
-        <a href="https://twitter.com/operation_code/status/728018497343660032" target="_blank">May 5, 2016</a>
-      </blockquote>
-    </div>
-  </div>
-</div>
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
+
+			<div class="cd-timeline-content">
+				<h2>New Twitter handle</h2>
+				<p>
+            Operation Code changes it's Twitter handle to <a href="http://twitter.com/operation_code" target="_blank">@operation_code</a> for more effective branding, as well as <a href="http://instagram.com/operation_code" target="_blank">Instagram</a> and <a href="http://facebook.com/operationcode.org" target="_blank">Facebook</a>.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Formal launch</h2>
+				<p>
+            Formal launch of Operation Code. The <a href="http://calagator.org/events/1250468219" target="_blank">April 16th launch party</a> brings veteran coders, software developers, media and officials from U.S. Senator Ron Wyden and Congressman Blumenauer's office.
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              Friends of <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> for our Launch Party at <a href="https://twitter.com/epicodus" target="_blank">@epicodus</a> <a href="https://twitter.com/hashtag/tbt?src=hash" target="_blank">#tbt</a> <a href="http://t.co/mn6mKx7D23" target="_blank">pic.twitter.com/mn6mKx7D23</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/591485986875420673" target="_blank">April 24, 2015</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">April 24, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Slack channels created</h2>
+				<p>
+            Army veteran and software developer Fernando Paredes joins Operation Code and expands the Software Mentor Protégé Program to Peer-to-Peer mentorship using <a href="https://operation-code.slack.com/" target="_blank">Slack</a>. Paredes creates the following channels: Android, Ember, Go, HTML/CSS, iOS, Java, JavaScript, PHP, Python, and Ruby. Veterans now have instant access to a veterans coding community and software mentors accessible in the browser, desktop and via native app.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+    
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Contributing guide created</h2>
+				<p>
+            Software developers, Fernando Paredes, Nell Shamrell, and Eric McKenna help make Operation Code more open and developer user-friendly by creating a <a href="https://github.com/OperationCode/operationcode/blob/master/CONTRIBUTING.md" target="_blank">contributing guide</a>.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Airbnb sponsors</h2>
+				<p>
+            Global hospitality provider, <a href="https://www.airbnb.com/" target="_blank">Airbnb</a> sponsors Operation Code veterans lodging requirements while visiting San Francisco for Signal. HQ tour is <a href="https://www.instagram.com/p/21p5bFxUjd/?taken-by=davidcmolina" target="_blank">provided</a> and Airbnb becomes official lodging sponsor for veterans doing job interviews going forward.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
+
+			<div class="cd-timeline-content">
+				<h2>SignalConf</h2>
+				<p>
+            San Francisco-based, <a href="https://www.twilio.com/signal/2015" target="_blank">SignalConf</a> becomes 2nd software developer industry conference to support Operation Code veterans to keep coding and building software. Three scholarships are awarded to two Army vets, and one Navy vet. Operation Code veterans tour Twilio.</p></li>
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              Special shout out to <a href="https://twitter.com/twilio" target="_blank">@twilio</a> <a href="https://twitter.com/Airbnb" target="_blank">@Airbnb</a> for making it possible for our <a href="https://twitter.com/hashtag/veterans?src=hash" target="_blank">#veterans</a> to attend <a href="https://twitter.com/signalconf" target="_blank">@signalconf</a> this week. <a href="http://t.co/EWomd8fwq4" target="_blank">pic.twitter.com/EWomd8fwq4</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/600721740948312066" target="_blank">May 19, 2015</a>
+            </blockquote>
+
+        </p>
+				<span class="cd-date">May 19, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
+
+			<div class="cd-timeline-content">
+				<h2>SignalConf</h2>
+				<p>
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              Our team on the ground at <a href="https://twitter.com/twilio" target="_blank">@twilio</a> HQ w/ @TheINDIEHost. <a href="https://twitter.com/hashtag/SignalConf?src=hash" target="_blank">#SignalConf</a>
+              <a href="https://twitter.com/signalconf" target="_blank">@signalconf</a> <a href="http://t.co/3xq2f0VaSa" target="_blank">pic.twitter.com/3xq2f0VaSa</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/601187508160978944" target="_blank">May 21, 2015</a>
+            </blockquote>
+
+        </p>
+				<span class="cd-date">May 20, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
+
+			<div class="cd-timeline-content">
+				<h2>21st Amendment meetup</h2>
+				<p>
+            While in San Francisco, Operation Code Founder David Molina hosts a meetup at 21st Amendment that is attended by Elmer Thomas (SendGrid), Laura Gómez (Atipica), Nick Frost (Navy Veteran) and Pete Runyon (Marine Veteran). The following day Pete accompanies David on meetings throughout San Francisco.
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              Thank you <a href="https://twitter.com/21stAmendment" target="_blank">@21stAmendment</a> for last night, the amazing hospitality and excellent beer selection! <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> #👊 <a href="http://t.co/ySLX29i7Xt" target="_blank">pic.twitter.com/ySLX29i7Xt</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/601403833395347456" target="_blank">May 21, 2015</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">May 21, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Board of directors</h2>
+				<p>
+            To meet growth demands, Operation Code <a href="https://twitter.com/operation_code/status/614443994769027072" target="_blank">separates</a> from its fiscal sponsor/agent, The Cogostar Foundation, recruits new <a href="https://operationcode.org/blog/2015/09/30/announcing-operation-code-board-officers.html" target="_blank">founding governing board of directors</a> comprised of Army, Marine, and Navy veterans, an Army spouse, software developers and technology entrepreneurs, to include: Josh Carter, Aimee Knight, Nick Frost, Pete Runyon, Laura Gómez, Fernando Paredes, and Elmer Thomas. Operation Code incorporates as an Oregon nonprofit.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Stickers for everyone</h2>
+				<p>
+            <a href="https://www.stickermule.com/" target="_blank">Sticker Mule</a> sponsors stickers and we begin covering laptops everywhere.
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              Our <a href="https://twitter.com/stickermule" target="_blank">@stickermule</a>&#39;s fresh off the Oregon Trail. h/t <a href="https://twitter.com/hackhands" target="_blank">@hackhands</a> <a href="https://twitter.com/adorableio" target="_blank">@adorableio</a> <a href="https://twitter.com/hashtag/operationcode?src=hash">#operationcode</a> <a href="http://t.co/5BOhQXwkL7" target="_blank">pic.twitter.com/5BOhQXwkL7</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/607978609785962497" target="_blank">June 8, 2015</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">June 8, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Now accepting donations</h2>
+				<p>
+            Powered by Stripe, Operation Code incorporates SSL for the domain and begins accepting online donations.
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              Your request to have an in-house donation capable form has been heard. Thanks to <a href="https://twitter.com/stripe" target="_blank">@stripe</a> we&#39;re here! <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="http://t.co/B1NO0udWXd" target="_blank">pic.twitter.com/B1NO0udWXd</a></p>&mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/619872618317901825" target="_blank">July 11, 2015</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">July 11, 2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Jared Zoneraich joins the team</h2>
+				<p>
+            Founder of one of the first and largest high school hackathons, hackBCA, Jared Zoneraich joins the Operation Code advisory team.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Welcome Mark Kerr</h2>
+				<p>
+            Attorney, entrepreneur and ex-Army Captain, Mark Kerr <a href="https://operationcode.org/blog/2015/11/08/introducing-the-new-operation-code-board-chair.html">
+            joins</a> the Operation Code board of directors. He is elected chair of the board, and the board begins having regular conference calls
+            focusing on infrastructure, processes &amp; procedures, and fundraising strategy.
+        </p>
+				<span class="cd-date">2015</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Hack summit</h2>
+				<p>
+            <a href="https://hacksummit.org/" target="_blank">hack.summit()</a> adds Operation Code to its list of coding nonprofits, and more military veterans attend.
+            <blockquote class="twitter-tweet" data-lang="en">
+              <p lang="en" dir="ltr">Wondering what happened to hack.summit() and when? Mark it on your calendars: Feb 22-25th -
+              <a href="https://t.co/pfExk2VeTB" target="_blank">https://t.co/pfExk2VeTB</a> <a href="https://t.co/QoQj9QlRIG" target="_blank">pic.twitter.com/QoQj9QlRIG</a></p>
+              &mdash; Operation Code (@operation_code) <a href="https://twitter.com/operation_code/status/692580768313384960" target="_blank">January 28, 2016</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">January 28, 2016</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-yellow"></div>
+
+			<div class="cd-timeline-content">
+				<h2>Speakeasy</h2>
+				<p>
+            <a href="http://speakeasy.co/" target="_blank">Speakeasy</a> joins as the Operation Code conference sponsor. The Operation Code Battle Rhythym pencils in the
+            first Tuesday of the month for its governing Board of Director calls.
+        </p>
+				<span class="cd-date">2016</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-red"></div>
+
+			<div class="cd-timeline-content">
+				<h2>501(c)(3) Application</h2>
+				<p>
+            Operation Code prepares 501(c)(3) application. Marine Veteran and Board Secretary/Treasurer Pete Runyon drops
+            $850 for the fee and its shipped.
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Things are moving.
+              <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a> <a href="https://t.co/usY95axRmr" target="_blank">pic.twitter.com/usY95axRmr</a>
+              </p>&mdash; Operation Code (@operation_code)
+              <a href="https://twitter.com/operation_code/status/707267330066108417" target="_blank">March 8, 2016</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">March 8, 2016</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+
+    <div class="cd-timeline-block">
+			<div class="cd-timeline-img cd-green"></div>
+
+			<div class="cd-timeline-content">
+				<h2>501(c)(3) Approved</h2>
+				<p>
+            ~41 business days later, Operation Code is a 501(c)(3) nonprofit organization.
+            <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">
+              ... And, ~41 business days later we&#39;re tax-exempt. Now back to work. Together we are
+              <a href="https://twitter.com/hashtag/operationcode?src=hash" target="_blank">#operationcode</a>.
+              <a href="https://t.cod/SZYij4Qs2R" target="_blank">pic.twitter.com/SZYij4Qs2R</a></p>&mdash; Operation Code (@operation_code)
+              <a href="https://twitter.com/operation_code/status/728018497343660032" target="_blank">May 5, 2016</a>
+            </blockquote>
+        </p>
+				<span class="cd-date">May 5, 2016</span>
+			</div> <!-- cd-timeline-content -->
+		</div> <!-- cd-timeline-block -->
+  </section>
 
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+<script src="assets/timeline.js"></script>


### PR DESCRIPTION
I converted the history page to a timeline using the link mentioned in the issue at https://codyhouse.co/demo/vertical-timeline/index.html. I made a couple small changes to the CSS from that sournce, notably removing the global styles being applied. I also didn't include the image tags in the HTML for the history page since they were for a movie/picture/location, and that didn't seem to fit well with the timeline here, so I just alternated the colors.

Any items int he history page with Tweets, I added noted with the date on the post, but for the others I was just able to put the year. We may be able to go back and add more if we can get more precise dates on them.

One additional note. There were two items in the history page, one talking about starting to accept donations from Stripe and another about Sticker Mule that were out of order based on the dates int he posts on Twitter, so I swapped them in the timeline. 